### PR TITLE
Derive Debug for Backend enum

### DIFF
--- a/aurex-backend/src/dispatch.rs
+++ b/aurex-backend/src/dispatch.rs
@@ -1,5 +1,6 @@
 //! Backend dispatch stub.
 
+#[derive(Debug)]
 pub enum Backend {
     Cpu,
     #[allow(dead_code)]


### PR DESCRIPTION
## Summary
- derive `Debug` for the `Backend` enum so it can be printed during tests

## Testing
- `cargo test`