### PR TITLE
Add Codex prompt bundle and test scaffolds

### DIFF
--- a/Aurex-AMDUDA/README_codex.md
+++ b/Aurex-AMDUDA/README_codex.md
@@ -1,0 +1,60 @@
+# Aurex-AMDUDA Codex Prompt Library
+
+This folder provides **OpenAI Codex prompts** to generate modular, testable code for **Aurex-AMDUDA**, a vendor-agnostic CUDA-alternative runtime.
+
+---
+
+## 🎯 Key Points
+
+- **Core runtime first** (TensorOps, FSM, HAL)  
+- **Optional features:** AUREUS, HipCortex, Quantum Seed Engine (QSE)  
+- **No IDE dependency** — works with **Codex prompts** directly  
+- **Unit → SIT → UAT** test progression for modular development  
+
+---
+
+## 🚀 Development Workflow
+
+1. **Pick a prompt** from `codex_prompts/`  
+2. **Use OpenAI Codex**: Paste prompt into Codex or Copilot Chat  
+3. **Generate code** → Save in `src/<module>.rs`  
+4. **Run tests** using Cargo (core-only first)  
+5. **Optional:** Enable feature flags for AUREUS/HipCortex/QSE
+
+---
+
+## 🔧 Build & Test Commands
+
+**Core Runtime Only (Standalone)**
+
+```
+cargo build
+cargo test
+```
+
+**Enable AUREUS + HipCortex (Agentic)**
+
+```
+cargo build --features agentic
+cargo test --features agentic
+```
+
+**Full Runtime with QSE**
+
+```
+cargo build --features full
+cargo test --features full
+```
+
+---
+
+## ✅ Test Progression
+
+1. **Unit Tests** – Module correctness  
+2. **SIT** – Integrated LLM inference  
+3. **UAT** – Optional Reflexion/agentic scenarios
+
+---
+
+This library standardizes **prompt folding** for Codex-based AI‑assisted development.
+

--- a/Aurex-AMDUDA/codex_prompts/00_prompt_sop.md
+++ b/Aurex-AMDUDA/codex_prompts/00_prompt_sop.md
@@ -1,0 +1,26 @@
+# Prompt Folding SOP for Aurex-AMDUDA
+
+**Purpose:**  
+Ensure all Codex prompts generate **modular, testable Rust code** with optional features.
+
+**Template Prompt:**
+```
+[Role] You are an AI software engineer.
+[Context] We are building Aurex-AMDUDA: a CUDA-alternative core runtime with optional features.
+[Task] Generate <module_name> with:
+   - Core functionality first (standalone)
+   - Optional blocks for AUREUS, HipCortex, and QSE
+[Guidelines]
+   1. Core code compiles without features
+   2. Optional code wrapped with feature flags
+   3. Include inline CoT comments
+   4. Include a matching unit test
+```
+
+**Prompt Folding Layers:**
+1. Context – What module does  
+2. Task – Functions or features required  
+3. Reasoning – Step-by-step CoT planning  
+4. Validation – Unit/SIT/UAT instructions  
+5. Output – Code + comments + tests
+

--- a/Aurex-AMDUDA/codex_prompts/01_tensor_ops.md
+++ b/Aurex-AMDUDA/codex_prompts/01_tensor_ops.md
@@ -1,0 +1,22 @@
+# Module Prompt: amduda_core/tensor_ops.rs
+
+**Task:**  
+Implement TensorOps core API with multi-tier memory.
+
+**Requirements:**
+1. Core:
+   - tensor_mul(a, b)
+   - tensor_add(a, b)
+   - kv_cache_allocate(size, tier="gpu/cpu/nvme")
+2. Memory fallback: GPU → CPU → NVMe
+3. Optional:
+   - HipCortex: log KV allocations if enabled
+4. CoT Steps:
+   - Step 1: Allocate tensor
+   - Step 2: Dispatch to backend
+   - Step 3: Fallback to CPU if no GPU
+5. Unit Test:
+   - Multiply 2x2 matrices
+   - Allocate KV cache
+   - Verify result core-only
+

--- a/Aurex-AMDUDA/codex_prompts/02_procedural_fsm.md
+++ b/Aurex-AMDUDA/codex_prompts/02_procedural_fsm.md
@@ -1,0 +1,23 @@
+# Module Prompt: amduda_core/procedural_fsm.rs
+
+**Task:**  
+Implement FSM for LLM token streaming.
+
+**FSM States:**  
+- FetchToken  
+- KVCacheUpdate  
+- ComputeAttention  
+- OutputToken
+
+**Core:**  
+- Works standalone for Int4 token streaming
+
+**Optional:**  
+- HipCortex: KV trace logs  
+- AUREUS: Reflexion logging  
+- QSE: 1-bit regeneration fallback
+
+**Unit Test:**  
+- Simulate 10 tokens core-only  
+- Optional: Verify log output if features enabled
+

--- a/Aurex-AMDUDA/codex_prompts/03_hal_backends.md
+++ b/Aurex-AMDUDA/codex_prompts/03_hal_backends.md
@@ -1,0 +1,14 @@
+# Module Prompt: amduda_core/hal_backends.rs
+
+**Task:**
+Implement hardware abstraction layer backends for GPU and CPU execution.
+
+**Requirements:**
+1. Core:
+   - Define a `Backend` trait with a `compute` method.
+   - Provide `GpuBackend` and `CpuBackend` structs implementing the trait.
+2. Optional:
+   - `qse` feature adds a `quantum_hint` method on the trait.
+3. Unit Test:
+   - Instantiate both backends and ensure `compute` is called.
+

--- a/Aurex-AMDUDA/codex_prompts/04_aurex_lm.md
+++ b/Aurex-AMDUDA/codex_prompts/04_aurex_lm.md
@@ -1,0 +1,16 @@
+# Module Prompt: amduda_core/aurex_lm.rs
+
+**Task:**
+Create a minimal language model interface.
+
+**Requirements:**
+1. Core:
+   - Loader for model parameters.
+   - `forward` function producing logits.
+2. Optional:
+   - `aureus` feature adds Reflexion hooks.
+   - `hipcortex` logs key/value cache usage.
+   - `qse` enables quantization fallback.
+3. Unit Test:
+   - Call `forward` with dummy tensors and check shape of output.
+

--- a/Aurex-AMDUDA/codex_prompts/05_aurex_graph.md
+++ b/Aurex-AMDUDA/codex_prompts/05_aurex_graph.md
@@ -1,0 +1,15 @@
+# Module Prompt: amduda_core/aurex_graph.rs
+
+**Task:**
+Design a graph execution engine to schedule computation nodes.
+
+**Requirements:**
+1. Core:
+   - `Node` struct representing an operation.
+   - `Graph` struct storing nodes and edges.
+   - Simple scheduler that executes nodes in order.
+2. Optional:
+   - Feature-gated execution paths for specialized backends.
+3. Unit Test:
+   - Build a graph with two nodes and verify both execute.
+

--- a/Aurex-AMDUDA/codex_prompts/06_testing_sop.md
+++ b/Aurex-AMDUDA/codex_prompts/06_testing_sop.md
@@ -1,0 +1,13 @@
+# Testing SOP
+
+**Purpose:**
+Outline standardized testing flow for Aurex-AMDUDA modules.
+
+**Steps:**
+1. Run `cargo test` for core functionality.
+2. Run `cargo test --features agentic` to include AUREUS and HipCortex.
+3. Run `cargo test --features full` to enable QSE.
+
+**Progression:**
+- Unit Tests → integration tests (SIT) → user acceptance tests (UAT).
+

--- a/Aurex-AMDUDA/codex_prompts/07_end_to_end_examples.md
+++ b/Aurex-AMDUDA/codex_prompts/07_end_to_end_examples.md
@@ -1,0 +1,14 @@
+# End-to-End Examples Prompt
+
+**Goal:**
+Combine TensorOps and the procedural FSM to demonstrate a minimal inference pipeline.
+
+**Steps:**
+1. Load mock tensors for model weights.
+2. Stream tokens through the FSM using `tensor_mul` and `tensor_add`.
+3. Emit final output tokens.
+
+**Validation:**
+- Core example runs without any optional features.
+- Feature-gated examples may log additional information.
+

--- a/Aurex-AMDUDA/codex_prompts/08_reflexion_prompts.md
+++ b/Aurex-AMDUDA/codex_prompts/08_reflexion_prompts.md
@@ -1,0 +1,17 @@
+# Reflexion & Reasoning Prompts
+
+**Task:**  
+Integrate Reflexion logging optionally.
+
+**Core:**  
+- FSM works without Reflexion
+
+**Optional:**  
+1. Log FSM transitions to file if AUREUS enabled  
+2. Log KV cache states if HipCortex enabled  
+3. Capture 1-bit regeneration events if QSE enabled
+
+**Validation:**  
+- Core: Unit test runs without any features  
+- Optional: Reflexion log verified in feature-enabled SIT
+

--- a/Aurex-AMDUDA/tests/test_procedural_fsm.rs
+++ b/Aurex-AMDUDA/tests/test_procedural_fsm.rs
@@ -1,0 +1,12 @@
+#[test]
+fn test_fsm_core_10_tokens() {
+    for token in 0..10 {
+        println!("Processing token {}", token);
+
+        #[cfg(feature = "aureus")]
+        println!("AUREUS Reflexion hook for token {}", token);
+
+        #[cfg(feature = "qse")]
+        println!("QSE 1-bit regeneration executed for token {}", token);
+    }
+}

--- a/Aurex-AMDUDA/tests/test_quantization.rs
+++ b/Aurex-AMDUDA/tests/test_quantization.rs
@@ -1,0 +1,6 @@
+#[test]
+fn test_quantization_round_trip() {
+    let data = vec![0.0_f32, 0.5, -0.5];
+    let quantized: Vec<i8> = data.iter().map(|x| (x * 127.0) as i8).collect();
+    assert_eq!(quantized, vec![0, 63, -63]);
+}

--- a/Aurex-AMDUDA/tests/test_tensor_ops.rs
+++ b/Aurex-AMDUDA/tests/test_tensor_ops.rs
@@ -1,0 +1,10 @@
+#[test]
+fn test_tensor_ops_core() {
+    let a = ndarray::arr2(&[[1.0, 2.0], [3.0, 4.0]]);
+    let b = ndarray::arr2(&[[1.0, 0.0], [0.0, 1.0]]);
+    let result = a.dot(&b);
+    assert_eq!(result, a);
+
+    #[cfg(feature = "hipcortex")]
+    println!("HipCortex: KV cache allocation logged");
+}


### PR DESCRIPTION
## Summary
- add Codex prompt library with workflow instructions and build/test commands
- include prompt templates for tensor ops, FSM, HAL, and reflexion scenarios
- provide Rust test scaffolds for tensor operations, procedural FSM, and quantization

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_688f7dafe7ac83328eb4a04196387191