### PR TITLE
Implement runtime-driven procedural FSM

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -20,6 +20,10 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 [[package]]
 name = "amduda"
 version = "0.1.0"
+dependencies = [
+ "aurex-runtime",
+ "tokio",
+]
 
 [[package]]
 name = "async-trait"

--- a/amduda/Cargo.toml
+++ b/amduda/Cargo.toml
@@ -6,3 +6,9 @@ edition = "2021"
 [lib]
 name = "amduda"
 path = "src/lib.rs"
+
+[dependencies]
+aurex-runtime = { path = "../aurex-runtime" }
+
+[dev-dependencies]
+tokio = { version = "1", features = ["rt-multi-thread"] }

--- a/amduda/src/amduda_core/procedural_fsm.rs
+++ b/amduda/src/amduda_core/procedural_fsm.rs
@@ -1,20 +1,67 @@
-//! Simple FSM placeholder for token streaming.
+//! Runtime-driven finite state machine coordinating token processing.
 
- #[derive(Debug, PartialEq)]
- pub enum State {
+use aurex_runtime::{Runtime, RuntimeEvent};
+
+/// Possible states in the token processing pipeline.
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+pub enum State {
+    /// Fetch the next token from the model.
     FetchToken,
+    /// Update the key/value cache if needed.
     KVCacheUpdate,
+    /// Compute attention using the current token and cache.
     ComputeAttention,
+    /// Emit the processed token as output.
     OutputToken,
+    /// An unrecoverable error state.
+    Error,
 }
 
-pub fn run_fsm(steps: usize) -> Vec<State> {
-    let mut seq = Vec::new();
-    for _ in 0..steps {
-        seq.push(State::FetchToken);
-        seq.push(State::KVCacheUpdate);
-        seq.push(State::ComputeAttention);
-        seq.push(State::OutputToken);
-    }
-    seq
+/// A simple procedural state machine driven by [`RuntimeEvent`]s.
+pub struct ProceduralFsm {
+    state: State,
 }
+
+impl ProceduralFsm {
+    /// Create a new FSM starting in [`State::FetchToken`].
+    pub fn new() -> Self {
+        Self { state: State::FetchToken }
+    }
+
+    /// Get the current state.
+    pub fn state(&self) -> State {
+        self.state
+    }
+
+    /// Advance the FSM based on a runtime event.
+    pub fn on_event(&mut self, event: RuntimeEvent) -> State {
+        self.state = match (self.state, event) {
+            (State::FetchToken, RuntimeEvent::TokenFetched { cache_hit }) => {
+                if cache_hit {
+                    State::ComputeAttention
+                } else {
+                    State::KVCacheUpdate
+                }
+            }
+            (State::KVCacheUpdate, RuntimeEvent::CacheUpdated) => State::ComputeAttention,
+            (State::ComputeAttention, RuntimeEvent::AttentionComputed) => State::OutputToken,
+            (State::OutputToken, RuntimeEvent::TokenEmitted) => State::FetchToken,
+            (_, RuntimeEvent::Error) => State::Error,
+            // Unexpected events leave the state unchanged.
+            (s, _) => s,
+        };
+        self.state
+    }
+
+    /// Convenience helper that performs a runtime step and applies the resulting
+    /// event to the FSM.
+    pub async fn step_with_runtime(
+        &mut self,
+        runtime: &Runtime,
+        event: RuntimeEvent,
+    ) -> State {
+        let ev = runtime.step(event).await;
+        self.on_event(ev)
+    }
+}
+

--- a/amduda/tests/test_procedural_fsm.rs
+++ b/amduda/tests/test_procedural_fsm.rs
@@ -1,12 +1,63 @@
-use amduda::amduda_core::procedural_fsm::{run_fsm, State};
+use amduda::amduda_core::procedural_fsm::{ProceduralFsm, State};
+use aurex_runtime::{Runtime, RuntimeEvent};
+
+// Helper to run async code in tests without requiring the tokio macros.
+fn run_async<F: std::future::Future<Output = ()>>(fut: F) {
+    let rt = tokio::runtime::Runtime::new().expect("tokio runtime");
+    rt.block_on(fut);
+}
 
 #[test]
-fn test_fsm_sequence() {
-    let seq = run_fsm(1);
-    assert_eq!(seq, vec![
-        State::FetchToken,
-        State::KVCacheUpdate,
-        State::ComputeAttention,
-        State::OutputToken,
-    ]);
+fn fsm_branches_on_cache_hit() {
+    run_async(async {
+        let runtime = Runtime::default();
+        let mut fsm = ProceduralFsm::new();
+
+        // Cache hit should skip KV cache update and go directly to attention.
+        let state = fsm
+            .step_with_runtime(&runtime, RuntimeEvent::TokenFetched { cache_hit: true })
+            .await;
+        assert_eq!(state, State::ComputeAttention);
+
+        // Continue normal flow through attention and output back to fetch.
+        let state = fsm
+            .step_with_runtime(&runtime, RuntimeEvent::AttentionComputed)
+            .await;
+        assert_eq!(state, State::OutputToken);
+        let state = fsm
+            .step_with_runtime(&runtime, RuntimeEvent::TokenEmitted)
+            .await;
+        assert_eq!(state, State::FetchToken);
+
+        // Cache miss requires KV cache update before attention.
+        let state = fsm
+            .step_with_runtime(&runtime, RuntimeEvent::TokenFetched { cache_hit: false })
+            .await;
+        assert_eq!(state, State::KVCacheUpdate);
+        let state = fsm
+            .step_with_runtime(&runtime, RuntimeEvent::CacheUpdated)
+            .await;
+        assert_eq!(state, State::ComputeAttention);
+    });
 }
+
+#[test]
+fn fsm_handles_errors() {
+    run_async(async {
+        let runtime = Runtime::default();
+        let mut fsm = ProceduralFsm::new();
+
+        // Any error event should transition to the error state regardless of current state.
+        let state = fsm
+            .step_with_runtime(&runtime, RuntimeEvent::Error)
+            .await;
+        assert_eq!(state, State::Error);
+
+        // After entering Error state, further events should not change the state.
+        let state = fsm
+            .step_with_runtime(&runtime, RuntimeEvent::TokenEmitted)
+            .await;
+        assert_eq!(state, State::Error);
+    });
+}
+

--- a/aurex-runtime/src/lib.rs
+++ b/aurex-runtime/src/lib.rs
@@ -1,13 +1,33 @@
 //! AUREX runtime orchestrates agent execution and dispatches operations to the appropriate backend.
 use async_trait::async_trait;
 
+/// Events emitted by the runtime to drive higher level state machines.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RuntimeEvent {
+    /// A token was fetched from the model. `cache_hit` indicates whether the KV
+    /// cache already contains the necessary values and the update phase can be
+    /// skipped.
+    TokenFetched { cache_hit: bool },
+    /// The KV cache has been updated and is ready for attention computation.
+    CacheUpdated,
+    /// Attention computation has completed.
+    AttentionComputed,
+    /// A token has been emitted as output.
+    TokenEmitted,
+    /// An unrecoverable error occurred.
+    Error,
+}
+
 #[derive(Default)]
 pub struct Runtime;
 
 impl Runtime {
-    pub async fn step(&self) {
-        // placeholder step logic
-        println!("runtime step");
+    /// Perform a single runtime step and return the resulting event. In this
+    /// prototype implementation the event is simply echoed back, allowing tests
+    /// and higher level logic to simulate runtime behaviour.
+    pub async fn step(&self, event: RuntimeEvent) -> RuntimeEvent {
+        println!("runtime step: {:?}", event);
+        event
     }
 }
 


### PR DESCRIPTION
## Summary
- Replace placeholder sequence generator with runtime-driven procedural FSM
- Add RuntimeEvent enum and integrate FSM stepping with aurex-runtime
- Test FSM branching and error handling

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_688f87f2f8508332840f0c61a4ddb2ca