### PR TITLE
feat(memory): add tiered allocator and migration

### DIFF
--- a/amduda/src/amduda_core/memory_tiering.rs
+++ b/amduda/src/amduda_core/memory_tiering.rs
@@ -1,13 +1,160 @@
 //! Simulated multi-tier memory manager.
+//!
+//! The manager detects device capabilities and allocates memory across GPU,
+//! CPU and NVMe tiers. When a tier is exhausted, data is migrated to the next
+//! slower tier to act as a simple cache hierarchy.
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Clone, Copy)]
 pub enum MemoryTier {
     Gpu,
     Cpu,
     Nvme,
 }
 
-pub fn allocate(_bytes: usize) -> MemoryTier {
-    // Placeholder strategy: always allocate on CPU for now.
-    MemoryTier::Cpu
+/// Runtime capabilities of the system.
+#[derive(Debug, Clone, Copy)]
+pub struct DeviceCapabilities {
+    pub has_gpu: bool,
+    pub has_nvme: bool,
+}
+
+impl DeviceCapabilities {
+    /// Detects capabilities from environment variables.
+    pub fn detect() -> Self {
+        let has_gpu = std::env::var("AMDUDA_HAS_GPU")
+            .map(|v| v == "1")
+            .unwrap_or(false);
+        let has_nvme = std::env::var("AMDUDA_HAS_NVME")
+            .map(|v| v == "1")
+            .unwrap_or(false);
+        Self { has_gpu, has_nvme }
+    }
+}
+
+/// Simple hierarchical memory manager.
+#[derive(Debug)]
+pub struct MemoryManager {
+    caps: DeviceCapabilities,
+    gpu_limit: usize,
+    cpu_limit: usize,
+    nvme_limit: usize,
+    gpu_used: usize,
+    cpu_used: usize,
+    nvme_used: usize,
+}
+
+impl MemoryManager {
+    /// Create a manager with default tier limits.
+    pub fn new(caps: DeviceCapabilities) -> Self {
+        Self::new_with_limits(caps, 1024, 8 * 1024, usize::MAX)
+    }
+
+    /// Create a manager with explicit limits for each tier.
+    pub fn new_with_limits(
+        caps: DeviceCapabilities,
+        gpu_limit: usize,
+        cpu_limit: usize,
+        nvme_limit: usize,
+    ) -> Self {
+        Self {
+            caps,
+            gpu_limit,
+            cpu_limit,
+            nvme_limit,
+            gpu_used: 0,
+            cpu_used: 0,
+            nvme_used: 0,
+        }
+    }
+
+    /// Allocates memory using a caching hierarchy. New allocations prefer the
+    /// fastest tier (GPU) and trigger migrations when space is required.
+    pub fn allocate(&mut self, bytes: usize) -> MemoryTier {
+        if self.caps.has_gpu {
+            self.ensure_gpu_space(bytes);
+            self.gpu_used += bytes;
+            MemoryTier::Gpu
+        } else {
+            self.ensure_cpu_space(bytes);
+            if self.cpu_used + bytes <= self.cpu_limit {
+                self.cpu_used += bytes;
+                MemoryTier::Cpu
+            } else {
+                self.nvme_used += bytes;
+                MemoryTier::Nvme
+            }
+        }
+    }
+
+    /// Manually migrate data between tiers.
+    pub fn migrate(&mut self, from: MemoryTier, to: MemoryTier, bytes: usize) {
+        match (from, to) {
+            (MemoryTier::Gpu, MemoryTier::Cpu) => {
+                self.ensure_cpu_space(bytes);
+                let moved = bytes.min(self.gpu_used);
+                self.gpu_used -= moved;
+                self.cpu_used += moved;
+            }
+            (MemoryTier::Cpu, MemoryTier::Gpu) => {
+                if self.caps.has_gpu {
+                    self.ensure_gpu_space(bytes);
+                    let moved = bytes.min(self.cpu_used);
+                    self.cpu_used -= moved;
+                    self.gpu_used += moved;
+                }
+            }
+            (MemoryTier::Cpu, MemoryTier::Nvme) => {
+                if self.caps.has_nvme {
+                    let moved = bytes.min(self.cpu_used);
+                    self.cpu_used -= moved;
+                    self.nvme_used += moved;
+                }
+            }
+            (MemoryTier::Nvme, MemoryTier::Cpu) => {
+                let moved = bytes.min(self.nvme_used);
+                self.ensure_cpu_space(moved);
+                self.nvme_used -= moved;
+                self.cpu_used += moved;
+            }
+            _ => {}
+        }
+    }
+
+    /// Current usage of each tier.
+    pub fn usage(&self) -> (usize, usize, usize) {
+        (self.gpu_used, self.cpu_used, self.nvme_used)
+    }
+
+    fn ensure_gpu_space(&mut self, bytes: usize) {
+        if self.gpu_used + bytes <= self.gpu_limit {
+            return;
+        }
+        let needed = self.gpu_used + bytes - self.gpu_limit;
+        self.ensure_cpu_space(needed);
+        let migrated = needed.min(self.gpu_used);
+        self.gpu_used -= migrated;
+        self.cpu_used += migrated;
+    }
+
+    fn ensure_cpu_space(&mut self, bytes: usize) {
+        if self.cpu_used + bytes <= self.cpu_limit {
+            return;
+        }
+        let needed = self.cpu_used + bytes - self.cpu_limit;
+        if self.caps.has_nvme && self.nvme_used + needed <= self.nvme_limit {
+            let migrated = needed.min(self.cpu_used);
+            self.cpu_used -= migrated;
+            self.nvme_used += migrated;
+        } else {
+            let dropped = needed.min(self.cpu_used);
+            self.cpu_used -= dropped;
+        }
+    }
+}
+
+/// Convenience allocation using detected capabilities with default limits.
+pub fn allocate(bytes: usize) -> MemoryTier {
+    let caps = DeviceCapabilities::detect();
+    let mut mgr = MemoryManager::new(caps);
+    mgr.allocate(bytes)
 }

--- a/amduda/tests/test_memory_tiering.rs
+++ b/amduda/tests/test_memory_tiering.rs
@@ -1,0 +1,50 @@
+use amduda::amduda_core::memory_tiering::{DeviceCapabilities, MemoryManager, MemoryTier};
+
+#[test]
+fn gpu_caching_and_migration() {
+    std::env::set_var("AMDUDA_HAS_GPU", "1");
+    std::env::set_var("AMDUDA_HAS_NVME", "1");
+    let caps = DeviceCapabilities::detect();
+    let mut mgr = MemoryManager::new_with_limits(caps, 64, 64, 256);
+
+    assert_eq!(mgr.allocate(32), MemoryTier::Gpu);
+    assert_eq!(mgr.usage(), (32, 0, 0));
+
+    assert_eq!(mgr.allocate(48), MemoryTier::Gpu);
+    assert_eq!(mgr.usage(), (64, 16, 0));
+
+    assert_eq!(mgr.allocate(64), MemoryTier::Gpu);
+    assert_eq!(mgr.usage(), (64, 64, 16));
+}
+
+#[test]
+fn cpu_and_nvme_fallback() {
+    std::env::set_var("AMDUDA_HAS_GPU", "0");
+    std::env::set_var("AMDUDA_HAS_NVME", "1");
+    let caps = DeviceCapabilities::detect();
+    let mut mgr = MemoryManager::new_with_limits(caps, 0, 64, 512);
+
+    assert_eq!(mgr.allocate(32), MemoryTier::Cpu);
+    assert_eq!(mgr.usage(), (0, 32, 0));
+
+    assert_eq!(mgr.allocate(64), MemoryTier::Cpu);
+    assert_eq!(mgr.usage(), (0, 64, 32));
+
+    assert_eq!(mgr.allocate(128), MemoryTier::Nvme);
+    assert_eq!(mgr.usage(), (0, 0, 224));
+}
+
+#[test]
+fn manual_migration() {
+    std::env::set_var("AMDUDA_HAS_GPU", "1");
+    std::env::set_var("AMDUDA_HAS_NVME", "1");
+    let caps = DeviceCapabilities::detect();
+    let mut mgr = MemoryManager::new_with_limits(caps, 64, 64, 256);
+
+    mgr.allocate(32);
+    mgr.migrate(MemoryTier::Gpu, MemoryTier::Cpu, 16);
+    assert_eq!(mgr.usage(), (16, 16, 0));
+
+    mgr.migrate(MemoryTier::Cpu, MemoryTier::Nvme, 8);
+    assert_eq!(mgr.usage(), (16, 8, 8));
+}

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -10,7 +10,8 @@ Aurex-AMDUDA aims to provide an AI-native compute runtime that unifies tensor op
    - Converts compute requests into procedural kernel executions.
    - Supports Int4/Int8/FP16 with optional 1-bit regenerative paths.
 3. **Multi-Tier Memory Manager**
-   - GPU Shared → CPU DRAM → NVMe paging.
+   - Detects GPU and NVMe capabilities at runtime.
+   - Maintains a caching hierarchy of GPU → CPU → NVMe with automatic migration when tiers are full.
 4. **Aurex-LM Core**
    - LLM inference for 7B–70B models with quantization.
    - Operates standalone without AUREUS or HipCortex dependencies.
@@ -18,3 +19,11 @@ Aurex-AMDUDA aims to provide an AI-native compute runtime that unifies tensor op
    - HipCortex symbolic memory.
    - AUREUS agent runtime.
    - Quantum Seed Engine for regenerative inference.
+
+## Memory Tiering Strategy
+
+AMDUDA detects available accelerators through environment variables and
+allocates memory on the fastest tier. GPU memory acts as a cache for hot data;
+when it fills, blocks are migrated to CPU DRAM and, if necessary, spilled to
+NVMe storage. The `MemoryManager` API also exposes manual migration routines to
+promote or demote data between tiers.


### PR DESCRIPTION
## Summary
- add capability detection and tiered memory manager
- support automatic caching and manual migration between GPU, CPU and NVMe
- document tiering strategy and add unit tests for allocation and migration

## Testing
- `cargo test -p amduda`