### PR TITLE
Add OpenCL backend and tests

### DIFF
--- a/amduda/src/hal_backends/mod.rs
+++ b/amduda/src/hal_backends/mod.rs
@@ -1,9 +1,9 @@
 //! Hardware abstraction layer backends.
 
-pub mod vulkan_backend;
-pub mod rocm_backend;
-pub mod opencl_backend;
 pub mod cpu_simd;
+pub mod opencl_backend;
+pub mod rocm_backend;
+pub mod vulkan_backend;
 
 /// Enumeration of the available backend types.  This is used by tests to ensure
 /// that the correct backend is selected from environment configuration.
@@ -15,6 +15,8 @@ pub enum BackendKind {
     Rocm,
     /// Vulkan compute backend.
     Vulkan,
+    /// OpenCL backend (CPU or GPU devices).
+    OpenCl,
 }
 
 /// Select a backend based on the `AUREX_BACKEND` environment variable.  If the
@@ -27,6 +29,7 @@ pub fn select_backend() -> BackendKind {
     {
         "rocm" if rocm_backend::RocmBackend::is_available() => BackendKind::Rocm,
         "vulkan" => BackendKind::Vulkan,
+        "opencl" if opencl_backend::OpenClBackend::is_available() => BackendKind::OpenCl,
         _ => BackendKind::CpuSimd,
     }
 }

--- a/amduda/src/hal_backends/opencl_backend.rs
+++ b/amduda/src/hal_backends/opencl_backend.rs
@@ -1,5 +1,141 @@
-//! OpenCL backend stub.
+//! OpenCL backend providing a very small emulation of OpenCL style device
+//! management.  The real project would use the `opencl3` crate (or similar) to
+//! interface with the OpenCL runtime.  The containers used for the unit tests do
+//! not ship with an OpenCL implementation, therefore this module provides a
+//! lightweight stub that models platform and device enumeration, basic context
+//! management and kernel compilation/launch paths.  Tensor operations simply
+//! fall back to the [`CpuFallback`] implementation which allows higher level
+//! code to exercise the dispatch and backend selection logic without requiring a
+//! functional OpenCL stack.
 
+use crate::amduda_core::tensor_ops::{CpuFallback, TensorOps};
+
+/// Type of an emulated OpenCL device.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum DeviceKind {
+    /// A device executing on the host CPU.
+    Cpu,
+    /// A device representing a discrete GPU.
+    Gpu,
+}
+
+/// Representation of an OpenCL device.  Only an identifier and the device kind
+/// are tracked which is sufficient for tests that validate dispatch paths.
+#[derive(Clone, Copy, Debug)]
+pub struct OpenClDevice {
+    pub id: usize,
+    pub kind: DeviceKind,
+    pub name: &'static str,
+}
+
+/// Minimal context holding the selected device.
+#[derive(Clone, Copy, Debug)]
+pub struct OpenClContext {
+    device: OpenClDevice,
+}
+
+/// Backend instance used by tests.  In a fully fledged implementation this
+/// would manage command queues, compiled kernels and device memory.
+#[derive(Clone, Copy, Debug)]
+pub struct OpenClBackend {
+    ctx: OpenClContext,
+}
+
+impl OpenClBackend {
+    /// Enumerate available OpenCL devices.  When the real runtime is not
+    /// available we emulate a single CPU and GPU device so that the rest of the
+    /// stack can exercise device selection and dispatch logic.
+    pub fn enumerate() -> Vec<OpenClDevice> {
+        vec![
+            OpenClDevice {
+                id: 0,
+                kind: DeviceKind::Cpu,
+                name: "OpenCL CPU",
+            },
+            OpenClDevice {
+                id: 1,
+                kind: DeviceKind::Gpu,
+                name: "OpenCL GPU",
+            },
+        ]
+    }
+
+    /// Convenience helper mirroring other backends.
+    pub fn is_available() -> bool {
+        !Self::enumerate().is_empty()
+    }
+
+    /// Create a new backend for the requested device kind.  When the requested
+    /// device is not present we fall back to the CPU device.
+    pub fn new(kind: DeviceKind) -> Self {
+        let device = Self::enumerate()
+            .into_iter()
+            .find(|d| d.kind == kind)
+            .unwrap_or(OpenClDevice {
+                id: 0,
+                kind: DeviceKind::Cpu,
+                name: "OpenCL CPU",
+            });
+        OpenClBackend {
+            ctx: OpenClContext { device },
+        }
+    }
+
+    /// Simulate kernel compilation.  In the stub implementation this is a
+    /// no-op, but it models the call that a real backend would have to perform.
+    fn compile_kernel(&self, _src: &str, _name: &str) {
+        // No-op for the emulated backend.
+    }
+
+    /// Launch a previously "compiled" kernel.  When OpenCL is unavailable we
+    /// simply execute the supplied closure on the host.
+    fn launch<F>(&self, f: F)
+    where
+        F: FnOnce(),
+    {
+        // A real implementation would enqueue the kernel on a command queue and
+        // wait for completion.  For the stub we directly execute the closure.
+        f();
+    }
+}
+
+impl TensorOps for OpenClBackend {
+    fn matmul(&self, a: &[f32], b: &[f32], m: usize, n: usize, k: usize) -> Vec<f32> {
+        let cpu = CpuFallback;
+        self.compile_kernel("", "matmul");
+        self.launch(|| {});
+        cpu.matmul(a, b, m, n, k)
+    }
+
+    fn conv2d(
+        &self,
+        input: &[f32],
+        kernel: &[f32],
+        input_shape: (usize, usize),
+        kernel_shape: (usize, usize),
+    ) -> Vec<f32> {
+        let cpu = CpuFallback;
+        self.compile_kernel("", "conv2d");
+        self.launch(|| {});
+        cpu.conv2d(input, kernel, input_shape, kernel_shape)
+    }
+
+    fn attention(&self, q: &[f32], k: &[f32], v: &[f32], dim: usize) -> Vec<f32> {
+        let cpu = CpuFallback;
+        self.compile_kernel("", "attention");
+        self.launch(|| {});
+        cpu.attention(q, k, v, dim)
+    }
+
+    fn layer_norm(&self, x: &[f32], gamma: &[f32], beta: &[f32], eps: f32) -> Vec<f32> {
+        let cpu = CpuFallback;
+        self.compile_kernel("", "layer_norm");
+        self.launch(|| {});
+        cpu.layer_norm(x, gamma, beta, eps)
+    }
+}
+
+/// Initialize the OpenCL backend by probing available devices.
 pub fn init() {
-    // Initialize OpenCL backend.
+    let _ = OpenClBackend::enumerate();
 }

--- a/amduda/tests/backend_selection.rs
+++ b/amduda/tests/backend_selection.rs
@@ -36,3 +36,10 @@ fn selects_vulkan_when_requested() {
         assert_eq!(hal_backends::select_backend(), BackendKind::Vulkan);
     });
 }
+
+#[test]
+fn selects_opencl_when_requested() {
+    with_backend_var(Some("opencl"), || {
+        assert_eq!(hal_backends::select_backend(), BackendKind::OpenCl);
+    });
+}

--- a/amduda/tests/test_tensor_ops.rs
+++ b/amduda/tests/test_tensor_ops.rs
@@ -1,5 +1,6 @@
 use amduda::amduda_core::tensor_ops::TensorOps;
 use amduda::hal_backends::cpu_simd::CpuSimdBackend;
+use amduda::hal_backends::opencl_backend::{DeviceKind, OpenClBackend};
 use amduda::hal_backends::rocm_backend::RocmBackend;
 use amduda::hal_backends::vulkan_backend::VulkanBackend;
 
@@ -46,4 +47,23 @@ fn rocm_backend_ops() {
 #[test]
 fn vulkan_backend_ops() {
     run_backend(&VulkanBackend);
+}
+
+#[test]
+fn opencl_cpu_backend_ops() {
+    let backend = OpenClBackend::new(DeviceKind::Cpu);
+    run_backend(&backend);
+}
+
+#[test]
+fn opencl_gpu_backend_ops() {
+    let backend = OpenClBackend::new(DeviceKind::Gpu);
+    run_backend(&backend);
+}
+
+#[test]
+fn opencl_device_enumeration() {
+    let devices = OpenClBackend::enumerate();
+    assert!(devices.iter().any(|d| d.kind == DeviceKind::Cpu));
+    assert!(devices.iter().any(|d| d.kind == DeviceKind::Gpu));
 }

--- a/aurex-backend/src/dispatch.rs
+++ b/aurex-backend/src/dispatch.rs
@@ -7,6 +7,8 @@ pub enum Backend {
     Rocm,
     #[allow(dead_code)]
     Sycl,
+    #[allow(dead_code)]
+    OpenCl,
 }
 
 impl Backend {


### PR DESCRIPTION
## Summary
- add stubbed OpenCL backend with device enumeration, context, and TensorOps implementation
- expose OpenCL in backend selection and dispatch layers
- exercise OpenCL backend with CPU/GPU tests

## Testing
- `cargo test -p amduda` *(fails: No suitable version of LLVM was found system-wide)*

