### PR TITLE
Add configurable model loader with quantization and tiered weights

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -36,7 +36,11 @@ dependencies = [
  "criterion",
  "hip-runtime-sys",
  "llvm-sys",
+ "memmap2",
  "once_cell",
+ "serde",
+ "serde_json",
+ "tempfile",
  "tokio",
 ]
 
@@ -305,6 +309,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
+name = "errno"
+version = "0.3.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "778e2ac28f6c47af28e4907f13ffd1e1ddbd400980a9abd7c8df189bf578a5ad"
+dependencies = [
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
+name = "fastrand"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
 name = "fpga_npu"
 version = "0.1.0"
 
@@ -383,6 +403,18 @@ dependencies = [
  "pin-project-lite",
  "pin-utils",
  "slab",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26145e563e54f2cadc477553f1ec5ee650b00862f0a58bcd12cbdc5f0ea2d2f4"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasi 0.14.2+wasi-0.2.4",
 ]
 
 [[package]]
@@ -492,6 +524,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "linux-raw-sys"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
+
+[[package]]
 name = "llvm-sys"
 version = "150.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -527,6 +565,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
 
 [[package]]
+name = "memmap2"
+version = "0.5.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83faa42c0a078c393f6b29d5db232d8be22776a891f8f56e5284faee4a20b327"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "miniz_oxide"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -542,7 +589,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78bed444cc8a2160f01cbcf811ef18cac863ad68ae8ca62092e8db51d51c761c"
 dependencies = [
  "libc",
- "wasi",
+ "wasi 0.11.1+wasi-snapshot-preview1",
  "windows-sys",
 ]
 
@@ -658,6 +705,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
 name = "rayon"
 version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -720,6 +773,19 @@ name = "rustc-demangle"
 version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56f7d92ca342cea22a06f2121d944b4fd82af56988c270852495420f961d4ace"
+
+[[package]]
+name = "rustix"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11181fbabf243db407ef8df94a6ce0b2f9a733bd8be4ad02b4eda9602296cac8"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys",
+]
 
 [[package]]
 name = "rustversion"
@@ -841,6 +907,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "tempfile"
+version = "3.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8a64e3985349f2441a1a9ef0b853f869006c3855f2cda6862a94d26ebb9d6a1"
+dependencies = [
+ "fastrand",
+ "getrandom",
+ "once_cell",
+ "rustix",
+ "windows-sys",
+]
+
+[[package]]
 name = "tinytemplate"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -897,6 +976,15 @@ name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
+
+[[package]]
+name = "wasi"
+version = "0.14.2+wasi-0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9683f9a5a998d873c0d21fcbe3c083009670149a8fab228644b8bd36b2c48cb3"
+dependencies = [
+ "wit-bindgen-rt",
+]
 
 [[package]]
 name = "wasm-bindgen"
@@ -1069,3 +1157,12 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "wit-bindgen-rt"
+version = "0.39.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
+dependencies = [
+ "bitflags",
+]

--- a/amduda/Cargo.toml
+++ b/amduda/Cargo.toml
@@ -14,10 +14,14 @@ once_cell = "1"
 hip-runtime-sys = { version = "0.1.1", optional = true }
 ash = { version = "0.37", default-features = false, features = ["loaded"] }
 anyhow = "1"
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+memmap2 = "0.5"
 
 [dev-dependencies]
 tokio = { version = "1", features = ["rt-multi-thread"] }
 criterion = "0.5"
+tempfile = "3"
 
 [features]
 default = []

--- a/amduda/src/aurex_lm/model_loader.rs
+++ b/amduda/src/aurex_lm/model_loader.rs
@@ -1,6 +1,77 @@
-//! Placeholder for model loading functionality.
+//! Basic model loading utilities.
+//!
+//! The loader reads a JSON configuration describing the location of model
+//! weights and optional quantization parameters.  Weights are placed on a
+//! memory tier using the simulated [`MemoryManager`] and are either loaded
+//! into memory or memory‑mapped when they overflow CPU memory limits.
 
-pub fn load_model(_path: &str) -> Result<(), String> {
-    // Future implementation: load model weights and configuration.
-    Ok(())
+use crate::amduda_core::memory_tiering::{self, MemoryTier};
+use anyhow::Result;
+use memmap2::{Mmap, MmapOptions};
+use serde::{Deserialize, Serialize};
+use std::fs::{self, File};
+
+/// Supported on-disk quantized weight formats.
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum Quantization {
+    Int4,
+    Int8,
+}
+
+/// Configuration for loading a model from disk.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct ModelConfig {
+    pub name: String,
+    pub weight_path: String,
+    #[serde(default)]
+    pub quantization: Option<Quantization>,
+}
+
+/// Concrete representation of loaded weights.
+#[derive(Debug)]
+pub enum Weights {
+    /// Weights fully resident in CPU/GPU memory.
+    Memory(Vec<u8>),
+    /// Weights memory mapped from NVMe storage.
+    Mmap(Mmap),
+}
+
+/// Fully loaded model including configuration and weights.
+#[derive(Debug)]
+pub struct LoadedModel {
+    pub config: ModelConfig,
+    pub weights: Weights,
+    pub tier: MemoryTier,
+}
+
+/// Load a model configuration and its associated weights.
+pub fn load_model(path: &str) -> Result<LoadedModel> {
+    // Parse configuration.
+    let cfg = fs::read_to_string(path)?;
+    let config: ModelConfig = serde_json::from_str(&cfg)?;
+
+    // Determine allocation tier based on weight size.
+    let metadata = fs::metadata(&config.weight_path)?;
+    let size = metadata.len() as usize;
+    let tier = memory_tiering::allocate(size);
+
+    // Load or map weights depending on tier.
+    let weights = match tier {
+        MemoryTier::Nvme => {
+            let file = File::open(&config.weight_path)?;
+            let mmap = unsafe { MmapOptions::new().map(&file)? };
+            Weights::Mmap(mmap)
+        }
+        _ => {
+            let data = fs::read(&config.weight_path)?;
+            Weights::Memory(data)
+        }
+    };
+
+    Ok(LoadedModel {
+        config,
+        weights,
+        tier,
+    })
 }

--- a/amduda/tests/test_model_loader.rs
+++ b/amduda/tests/test_model_loader.rs
@@ -1,0 +1,48 @@
+use amduda::amduda_core::memory_tiering::MemoryTier;
+use amduda::aurex_lm::model_loader::{load_model, Quantization, Weights};
+use serde_json::json;
+use tempfile::tempdir;
+
+fn write_dummy_model(size: usize, quant: &str) -> std::path::PathBuf {
+    let dir = tempdir().unwrap();
+    let weights_path = dir.path().join("weights.bin");
+    std::fs::write(&weights_path, vec![1u8; size]).unwrap();
+    let config_path = dir.path().join("config.json");
+    let cfg = json!({
+        "name": "dummy",
+        "weight_path": weights_path,
+        "quantization": quant,
+    });
+    std::fs::write(&config_path, serde_json::to_vec(&cfg).unwrap()).unwrap();
+    // Keep directory alive by leaking it; tests are short lived.
+    std::mem::forget(dir);
+    config_path
+}
+
+#[test]
+fn test_load_model_from_disk() {
+    std::env::set_var("AMDUDA_HAS_GPU", "0");
+    std::env::set_var("AMDUDA_HAS_NVME", "0");
+    let config = write_dummy_model(4, "int8");
+    let model = load_model(config.to_str().unwrap()).unwrap();
+    assert_eq!(model.config.quantization, Some(Quantization::Int8));
+    assert_eq!(model.tier, MemoryTier::Cpu);
+    match model.weights {
+        Weights::Memory(data) => assert_eq!(data, vec![1u8; 4]),
+        _ => panic!("expected in-memory weights"),
+    }
+}
+
+#[test]
+fn test_load_model_mmap() {
+    std::env::set_var("AMDUDA_HAS_GPU", "0");
+    std::env::set_var("AMDUDA_HAS_NVME", "1");
+    let config = write_dummy_model(9000, "int4");
+    let model = load_model(config.to_str().unwrap()).unwrap();
+    assert_eq!(model.config.quantization, Some(Quantization::Int4));
+    assert_eq!(model.tier, MemoryTier::Nvme);
+    match model.weights {
+        Weights::Mmap(mmap) => assert_eq!(mmap.len(), 9000),
+        _ => panic!("expected mmap weights"),
+    }
+}


### PR DESCRIPTION
## Summary
- implement model loader that parses JSON config, selects memory tier, and memory-maps NVMe weights
- support INT4/INT8 quantization options
- add tests for loading dummy models from disk and memory-mapped files

## Testing
- `cargo test -p amduda`
- `cargo test -p amduda --test test_model_loader`
