### PR TITLE
feat: add sliding window paged attention

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -40,6 +40,7 @@ dependencies = [
  "once_cell",
  "serde",
  "serde_json",
+ "serial_test",
  "tempfile",
  "tokio",
 ]

--- a/amduda/Cargo.toml
+++ b/amduda/Cargo.toml
@@ -9,7 +9,7 @@ path = "src/lib.rs"
 
 [dependencies]
 aurex-runtime = { path = "../aurex-runtime" }
-llvm-sys = "150"
+llvm-sys = { version = "150", optional = true }
 once_cell = "1"
 hip-runtime-sys = { version = "0.1.1", optional = true }
 ash = { version = "0.37", default-features = false, features = ["loaded"] }
@@ -22,10 +22,12 @@ memmap2 = "0.5"
 tokio = { version = "1", features = ["rt-multi-thread"] }
 criterion = "0.5"
 tempfile = "3"
+serial_test = "2"
 
 [features]
 default = []
 rocm = ["hip-runtime-sys"]
+jit = ["llvm-sys"]
 
 [[bench]]
 name = "simd_vs_scalar"

--- a/amduda/src/amduda_core/mod.rs
+++ b/amduda/src/amduda_core/mod.rs
@@ -1,6 +1,7 @@
 //! Core runtime components: tensor ops, procedural FSM, and memory tiering.
 
-pub mod tensor_ops;
-pub mod procedural_fsm;
-pub mod memory_tiering;
+#[cfg(feature = "jit")]
 pub mod jit_compiler;
+pub mod memory_tiering;
+pub mod procedural_fsm;
+pub mod tensor_ops;

--- a/amduda/src/aurex_lm/paged_attention.rs
+++ b/amduda/src/aurex_lm/paged_attention.rs
@@ -1,5 +1,133 @@
-//! Placeholder for paged attention mechanisms.
+//! Sliding-window paged attention leveraging the memory tiering subsystem.
+//!
+//! This is a very small reference implementation that demonstrates how key
+//! and value pages may be allocated across memory tiers and migrated for a
+//! sliding‑window attention computation.  The algorithm is intentionally
+//! simple: for each query position we attend only to the most recent
+//! `window` keys.
 
-pub fn compute_attention() {
-    // Future implementation: attention with paging.
+use crate::amduda_core::memory_tiering::{DeviceCapabilities, MemoryManager, MemoryTier};
+use std::mem::size_of;
+
+/// Result of a paged attention invocation.
+#[derive(Debug)]
+pub struct AttentionResult {
+    pub output: Vec<f32>,
+    pub k_tier: MemoryTier,
+    pub v_tier: MemoryTier,
+}
+
+/// Paged attention engine owning a [`MemoryManager`].
+#[derive(Debug)]
+pub struct PagedAttention {
+    mgr: MemoryManager,
+}
+
+impl PagedAttention {
+    /// Create a new engine with default tier limits.
+    pub fn new(caps: DeviceCapabilities) -> Self {
+        Self {
+            mgr: MemoryManager::new(caps),
+        }
+    }
+
+    /// Create a new engine with explicit tier limits, useful for tests.
+    pub fn new_with_limits(
+        caps: DeviceCapabilities,
+        gpu_limit: usize,
+        cpu_limit: usize,
+        nvme_limit: usize,
+    ) -> Self {
+        Self {
+            mgr: MemoryManager::new_with_limits(caps, gpu_limit, cpu_limit, nvme_limit),
+        }
+    }
+
+    /// Expose tier usage for tests.
+    pub fn usage(&self) -> (usize, usize, usize) {
+        self.mgr.usage()
+    }
+
+    /// Compute sliding‑window attention.
+    ///
+    /// * `q` – flattened query vectors of length `n_q * d`.
+    /// * `k` – flattened key vectors of length `n_k * d`.
+    /// * `v` – flattened value vectors of length `n_k * d`.
+    /// * `d` – feature dimension.
+    /// * `window` – number of previous tokens each query attends to.
+    pub fn compute(
+        &mut self,
+        q: &[f32],
+        k: &[f32],
+        v: &[f32],
+        d: usize,
+        window: usize,
+    ) -> AttentionResult {
+        assert_eq!(k.len(), v.len());
+        assert_eq!(q.len() % d, 0);
+        assert_eq!(k.len() % d, 0);
+
+        let n_q = q.len() / d;
+        let n_k = k.len() / d;
+        assert_eq!(n_q, n_k, "q, k and v must have the same number of tokens");
+
+        // Allocate key/value buffers using tiering.
+        let byte_len = k.len() * size_of::<f32>();
+        let k_tier = self.mgr.allocate(byte_len);
+        let v_tier = self.mgr.allocate(byte_len);
+
+        // Pull the working set for the sliding window into CPU memory if it
+        // resides on NVMe.  This models a simple cache for large contexts.
+        if matches!(k_tier, MemoryTier::Nvme) {
+            let window_bytes = window * d * size_of::<f32>();
+            self.mgr
+                .migrate(MemoryTier::Nvme, MemoryTier::Cpu, window_bytes);
+        }
+        if matches!(v_tier, MemoryTier::Nvme) {
+            let window_bytes = window * d * size_of::<f32>();
+            self.mgr
+                .migrate(MemoryTier::Nvme, MemoryTier::Cpu, window_bytes);
+        }
+
+        let mut output = vec![0f32; n_q * d];
+        for i in 0..n_q {
+            let q_i = &q[i * d..(i + 1) * d];
+            let start = if i >= window { i + 1 - window } else { 0 };
+
+            // Compute unnormalised scores.
+            let mut scores = Vec::new();
+            for j in start..=i {
+                let k_j = &k[j * d..(j + 1) * d];
+                let dot: f32 = q_i.iter().zip(k_j.iter()).map(|(a, b)| a * b).sum();
+                scores.push((j, dot));
+            }
+
+            // Softmax normalisation.
+            let max_score = scores
+                .iter()
+                .map(|(_, s)| *s)
+                .fold(f32::NEG_INFINITY, f32::max);
+            let mut denom = 0f32;
+            let mut weights = Vec::new();
+            for &(_, s) in &scores {
+                let w = (s - max_score).exp();
+                denom += w;
+                weights.push(w);
+            }
+
+            for ((j, _), w) in scores.iter().zip(weights.iter()) {
+                let weight = *w / denom;
+                let v_j = &v[*j * d..(*j + 1) * d];
+                for (out, val) in output[i * d..(i + 1) * d].iter_mut().zip(v_j.iter()) {
+                    *out += weight * val;
+                }
+            }
+        }
+
+        AttentionResult {
+            output,
+            k_tier,
+            v_tier,
+        }
+    }
 }

--- a/amduda/tests/backend_selection.rs
+++ b/amduda/tests/backend_selection.rs
@@ -1,4 +1,5 @@
 use amduda::hal_backends::{self, BackendKind};
+use serial_test::serial;
 
 // Helper to run selection with environment variable.
 fn with_backend_var<F: FnOnce()>(val: Option<&str>, f: F) {
@@ -17,6 +18,7 @@ fn with_backend_var<F: FnOnce()>(val: Option<&str>, f: F) {
 }
 
 #[test]
+#[serial]
 fn default_falls_back_to_cpu() {
     with_backend_var(None, || {
         assert_eq!(hal_backends::select_backend(), BackendKind::CpuSimd);
@@ -24,6 +26,7 @@ fn default_falls_back_to_cpu() {
 }
 
 #[test]
+#[serial]
 fn selects_rocm_when_requested() {
     with_backend_var(Some("rocm"), || {
         assert_eq!(hal_backends::select_backend(), BackendKind::Rocm);
@@ -31,6 +34,7 @@ fn selects_rocm_when_requested() {
 }
 
 #[test]
+#[serial]
 fn selects_vulkan_when_requested() {
     with_backend_var(Some("vulkan"), || {
         if hal_backends::vulkan_backend::VulkanBackend::is_available() {
@@ -42,6 +46,7 @@ fn selects_vulkan_when_requested() {
 }
 
 #[test]
+#[serial]
 fn selects_opencl_when_requested() {
     with_backend_var(Some("opencl"), || {
         assert_eq!(hal_backends::select_backend(), BackendKind::OpenCl);
@@ -49,6 +54,7 @@ fn selects_opencl_when_requested() {
 }
 
 #[test]
+#[serial]
 fn selects_sycl_when_requested() {
     with_backend_var(Some("sycl"), || {
         assert_eq!(hal_backends::select_backend(), BackendKind::Sycl);

--- a/amduda/tests/jit_compiler.rs
+++ b/amduda/tests/jit_compiler.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "jit")]
+
 use amduda::amduda_core::jit_compiler::{compile_kernel, Device};
 
 #[test]

--- a/amduda/tests/test_paged_attention.rs
+++ b/amduda/tests/test_paged_attention.rs
@@ -1,0 +1,68 @@
+use amduda::amduda_core::memory_tiering::{DeviceCapabilities, MemoryTier};
+use amduda::aurex_lm::paged_attention::PagedAttention;
+
+fn naive_sliding_window(q: &[f32], k: &[f32], v: &[f32], d: usize, window: usize) -> Vec<f32> {
+    assert_eq!(k.len(), v.len());
+    let n = q.len() / d;
+    let mut out = vec![0f32; n * d];
+    for i in 0..n {
+        let q_i = &q[i * d..(i + 1) * d];
+        let start = if i >= window { i + 1 - window } else { 0 };
+
+        let mut scores = Vec::new();
+        for j in start..=i {
+            let k_j = &k[j * d..(j + 1) * d];
+            let dot: f32 = q_i.iter().zip(k_j.iter()).map(|(a, b)| a * b).sum();
+            scores.push((j, dot));
+        }
+
+        let max_score = scores
+            .iter()
+            .map(|(_, s)| *s)
+            .fold(f32::NEG_INFINITY, f32::max);
+        let mut denom = 0f32;
+        let mut weights = Vec::new();
+        for &(_, s) in &scores {
+            let w = (s - max_score).exp();
+            denom += w;
+            weights.push(w);
+        }
+
+        for ((j, _), w) in scores.iter().zip(weights.iter()) {
+            let weight = *w / denom;
+            let v_j = &v[*j * d..(*j + 1) * d];
+            for (o, val) in out[i * d..(i + 1) * d].iter_mut().zip(v_j.iter()) {
+                *o += weight * val;
+            }
+        }
+    }
+    out
+}
+
+#[test]
+fn sliding_window_attention_correctness_and_tiering() {
+    std::env::set_var("AMDUDA_HAS_GPU", "0");
+    std::env::set_var("AMDUDA_HAS_NVME", "1");
+    let caps = DeviceCapabilities::detect();
+    let mut attn = PagedAttention::new_with_limits(caps, 0, 16, 1024);
+
+    let d = 2;
+    let q = vec![1.0, 0.0, 0.0, 1.0, 1.0, 1.0, 0.5, 0.5];
+    let k = q.clone();
+    let v = vec![1.0, 0.0, 0.0, 1.0, 1.0, 1.0, 0.5, 1.0];
+    let window = 2;
+
+    let result = attn.compute(&q, &k, &v, d, window);
+    let expected = naive_sliding_window(&q, &k, &v, d, window);
+
+    assert!(result
+        .output
+        .iter()
+        .zip(expected.iter())
+        .all(|(a, b)| (a - b).abs() < 1e-5));
+    assert_eq!(result.k_tier, MemoryTier::Nvme);
+    assert_eq!(result.v_tier, MemoryTier::Nvme);
+
+    let usage = attn.usage();
+    assert_eq!(usage, (0, 16, 48));
+}


### PR DESCRIPTION
## Summary
- implement sliding-window paged attention with memory tier migrations
- gate LLVM JIT behind optional feature and serialize backend selection tests
- cover paged attention with unit tests

## Testing
- `cargo test -p amduda`
