### PR TITLE
Add quantization primitives and runtime precision control

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -34,6 +34,7 @@ dependencies = [
  "ash",
  "aurex-runtime",
  "criterion",
+ "half",
  "hip-runtime-sys",
  "llvm-sys",
  "memmap2",

--- a/amduda/Cargo.toml
+++ b/amduda/Cargo.toml
@@ -17,6 +17,7 @@ anyhow = "1"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 memmap2 = "0.5"
+half = "2"
 
 [dev-dependencies]
 tokio = { version = "1", features = ["rt-multi-thread"] }

--- a/amduda/src/aurex_lm/quantizer.rs
+++ b/amduda/src/aurex_lm/quantizer.rs
@@ -1,5 +1,87 @@
-//! Placeholder for quantization routines.
+//! Quantization and dequantization utilities for Aurex-LM.
+//!
+//! The routines implemented here perform simple per-tensor symmetric
+//! quantization.  INT8 and INT4 quantization return a scale factor that is
+//! required for dequantization while BF16 quantization simply truncates the
+//! mantissa of `f32` values.
 
-pub fn quantize() {
-    // Future implementation: Int4/Int8 quantization.
+use half::bf16;
+
+/// Quantize a slice of `f32` values into INT8 representation.
+///
+/// Returns the quantized values and the scaling factor used during
+/// quantization.
+pub fn quantize_int8(data: &[f32]) -> (Vec<i8>, f32) {
+    let max = data
+        .iter()
+        .fold(0.0_f32, |m, &v| m.max(v.abs()));
+    let scale = if max == 0.0 { 1.0 } else { max / 127.0 };
+    let quantized = data
+        .iter()
+        .map(|&v| {
+            let q = (v / scale).round();
+            q.clamp(-127.0, 127.0) as i8
+        })
+        .collect();
+    (quantized, scale)
 }
+
+/// Dequantize INT8 values back into `f32` using the provided scale.
+pub fn dequantize_int8(data: &[i8], scale: f32) -> Vec<f32> {
+    data.iter().map(|&v| v as f32 * scale).collect()
+}
+
+/// Quantize a slice of `f32` values into INT4 representation.
+///
+/// The returned vector packs two 4-bit signed values per byte.  The caller is
+/// expected to track the original length of the data for correct
+/// dequantization.
+pub fn quantize_int4(data: &[f32]) -> (Vec<u8>, f32) {
+    let max = data
+        .iter()
+        .fold(0.0_f32, |m, &v| m.max(v.abs()));
+    let scale = if max == 0.0 { 1.0 } else { max / 7.0 };
+    let mut out = Vec::with_capacity((data.len() + 1) / 2);
+    for chunk in data.chunks(2) {
+        let mut byte = 0u8;
+        for (i, &val) in chunk.iter().enumerate() {
+            let q = (val / scale).round().clamp(-8.0, 7.0) as i8;
+            let nibble = (q as i8 & 0x0F) as u8;
+            if i == 0 {
+                byte |= nibble;
+            } else {
+                byte |= nibble << 4;
+            }
+        }
+        out.push(byte);
+    }
+    (out, scale)
+}
+
+/// Dequantize INT4 values back into `f32` using the provided scale and
+/// original length of the data.
+pub fn dequantize_int4(data: &[u8], scale: f32, len: usize) -> Vec<f32> {
+    let mut out = Vec::with_capacity(len);
+    for byte in data {
+        let low = ((byte & 0x0F) as i8) << 4 >> 4; // sign extend
+        let high = ((byte >> 4) as i8) << 4 >> 4;
+        out.push(low as f32 * scale);
+        if out.len() == len {
+            break;
+        }
+        out.push(high as f32 * scale);
+    }
+    out
+}
+
+/// Quantize a slice of `f32` values into BF16 representation returning raw
+/// `u16` bit patterns.
+pub fn quantize_bf16(data: &[f32]) -> Vec<u16> {
+    data.iter().map(|&v| bf16::from_f32(v).to_bits()).collect()
+}
+
+/// Dequantize BF16 values represented as `u16` bit patterns back to `f32`.
+pub fn dequantize_bf16(data: &[u16]) -> Vec<f32> {
+    data.iter().map(|&v| bf16::from_bits(v).to_f32()).collect()
+}
+

--- a/amduda/tests/test_model_loader.rs
+++ b/amduda/tests/test_model_loader.rs
@@ -34,6 +34,16 @@ fn test_load_model_from_disk() {
 }
 
 #[test]
+fn test_load_model_bf16() {
+    std::env::set_var("AMDUDA_HAS_GPU", "0");
+    std::env::set_var("AMDUDA_HAS_NVME", "0");
+    let config = write_dummy_model(4, "bf16");
+    let model = load_model(config.to_str().unwrap()).unwrap();
+    assert_eq!(model.config.quantization, Some(Quantization::Bf16));
+    assert_eq!(model.tier, MemoryTier::Cpu);
+}
+
+#[test]
 fn test_load_model_mmap() {
     std::env::set_var("AMDUDA_HAS_GPU", "0");
     std::env::set_var("AMDUDA_HAS_NVME", "1");

--- a/amduda/tests/test_quantization.rs
+++ b/amduda/tests/test_quantization.rs
@@ -1,7 +1,34 @@
-use amduda::aurex_lm::quantizer::quantize;
+use amduda::aurex_lm::quantizer::{
+    dequantize_bf16, dequantize_int4, dequantize_int8, quantize_bf16, quantize_int4, quantize_int8,
+};
 
 #[test]
-fn test_quantize_placeholder() {
-    // The function does nothing yet but should be callable.
-    quantize();
+fn test_int8_round_trip() {
+    let data = [0.0_f32, 0.5, -0.5, 1.0, -1.0];
+    let (q, scale) = quantize_int8(&data);
+    let deq = dequantize_int8(&q, scale);
+    for (a, b) in data.iter().zip(deq.iter()) {
+        assert!((a - b).abs() < 1e-2);
+    }
 }
+
+#[test]
+fn test_int4_round_trip() {
+    let data = [0.0_f32, 1.0, -1.0, 0.5];
+    let (q, scale) = quantize_int4(&data);
+    let deq = dequantize_int4(&q, scale, data.len());
+    for (a, b) in data.iter().zip(deq.iter()) {
+        assert!((a - b).abs() < 1e-1);
+    }
+}
+
+#[test]
+fn test_bf16_round_trip() {
+    let data = [0.0_f32, 1.2345, -2.5, 3.75];
+    let q = quantize_bf16(&data);
+    let deq = dequantize_bf16(&q);
+    for (a, b) in data.iter().zip(deq.iter()) {
+        assert!((a - b).abs() < 1e-2);
+    }
+}
+

--- a/aurex-runtime/src/lib.rs
+++ b/aurex-runtime/src/lib.rs
@@ -18,8 +18,26 @@ pub enum RuntimeEvent {
     Error,
 }
 
-#[derive(Default)]
-pub struct Runtime;
+/// Numeric precision used by the runtime for model execution.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Precision {
+    F32,
+    Bf16,
+    Int8,
+    Int4,
+}
+
+pub struct Runtime {
+    precision: Precision,
+}
+
+impl Default for Runtime {
+    fn default() -> Self {
+        Self {
+            precision: Precision::F32,
+        }
+    }
+}
 
 impl Runtime {
     /// Perform a single runtime step and return the resulting event. In this
@@ -28,6 +46,17 @@ impl Runtime {
     pub async fn step(&self, event: RuntimeEvent) -> RuntimeEvent {
         println!("runtime step: {:?}", event);
         event
+    }
+
+    /// Update the runtime's numeric precision. This allows dynamic precision
+    /// scaling based on model or system requirements.
+    pub fn set_precision(&mut self, precision: Precision) {
+        self.precision = precision;
+    }
+
+    /// Return the currently configured numeric precision.
+    pub fn precision(&self) -> Precision {
+        self.precision
     }
 }
 


### PR DESCRIPTION
## Summary
- implement INT4/INT8/BF16 quantization and dequantization utilities
- support quantization selection and conversion in model loader
- expose runtime precision enum for dynamic scaling
- add unit tests validating round-trip accuracy and loader BF16 parsing

## Testing
- `cargo test`