### PR TITLE
Add dynamic plugin registry and FPGA/NPU plugin example

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -70,7 +70,7 @@ version = "0.37.3+1.3.251"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39e9c3835d686b0a6084ab4234fcd1b07dbf6e4767dce60874b12356a25ecd4a"
 dependencies = [
- "libloading",
+ "libloading 0.7.4",
 ]
 
 [[package]]
@@ -111,6 +111,7 @@ dependencies = [
  "async-trait",
  "aurex-backend",
  "aurex-kernel",
+ "libloading 0.8.8",
  "tokio",
 ]
 
@@ -338,6 +339,9 @@ checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 [[package]]
 name = "fpga_npu"
 version = "0.1.0"
+dependencies = [
+ "aurex-runtime",
+]
 
 [[package]]
 name = "futures"
@@ -532,6 +536,16 @@ checksum = "b67380fd3b2fbe7527a606e18729d21c6f3951633d0500574c4dc22d2d638b9f"
 dependencies = [
  "cfg-if",
  "winapi",
+]
+
+[[package]]
+name = "libloading"
+version = "0.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07033963ba89ebaf1584d767badaa2e8fcec21aedea6b8c0346d487d49c28667"
+dependencies = [
+ "cfg-if",
+ "windows-targets",
 ]
 
 [[package]]

--- a/aurex-plugins/fpga_npu/Cargo.toml
+++ b/aurex-plugins/fpga_npu/Cargo.toml
@@ -3,4 +3,8 @@ name = "fpga_npu"
 version = "0.1.0"
 edition = "2021"
 
+[lib]
+crate-type = ["cdylib", "rlib"]
+
 [dependencies]
+aurex-runtime = { path = "../../aurex-runtime" }

--- a/aurex-plugins/fpga_npu/src/lib.rs
+++ b/aurex-plugins/fpga_npu/src/lib.rs
@@ -1,5 +1,26 @@
-//! Experimental FPGA/NPU backend plugin stub.
+#![allow(improper_ctypes_definitions)]
 
-pub fn init() {
-    println!("FPGA/NPU plugin initialized");
+use aurex_runtime::BackendPlugin;
+
+/// Simple FPGA/NPU backend plugin example.
+pub struct FpgaNpuPlugin;
+
+impl BackendPlugin for FpgaNpuPlugin {
+    fn name(&self) -> &'static str {
+        "fpga_npu"
+    }
+
+    fn initialize(&self) {
+        println!("FPGA/NPU plugin initialized");
+    }
+
+    fn execute(&self) {
+        println!("FPGA/NPU plugin executed");
+    }
+}
+
+/// Exported constructor called by the runtime to instantiate the plugin.
+#[no_mangle]
+pub extern "C" fn create_plugin() -> *mut dyn BackendPlugin {
+    Box::into_raw(Box::new(FpgaNpuPlugin))
 }

--- a/aurex-runtime/Cargo.toml
+++ b/aurex-runtime/Cargo.toml
@@ -8,3 +8,4 @@ aurex-kernel = { path = "../aurex-kernel" }
 aurex-backend = { path = "../aurex-backend" }
 async-trait = "0.1"
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
+libloading = "0.8"

--- a/aurex-runtime/examples/plugin_demo.rs
+++ b/aurex-runtime/examples/plugin_demo.rs
@@ -1,0 +1,23 @@
+use aurex_runtime::PluginRegistry;
+use std::path::PathBuf;
+
+fn main() {
+    let mut registry = PluginRegistry::new();
+    // Build path to the plugin shared library within the workspace target directory.
+    let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    path.push("..");
+    path.push("target");
+    path.push("debug");
+    path.push(format!(
+        "{}fpga_npu.{}",
+        std::env::consts::DLL_PREFIX,
+        std::env::consts::DLL_EXTENSION
+    ));
+    let path_str = path.to_string_lossy().into_owned();
+
+    unsafe {
+        registry.load(&path_str).expect("failed to load plugin");
+    }
+    // Execute the plugin once loaded.
+    registry.execute("fpga_npu");
+}

--- a/aurex-runtime/src/lib.rs
+++ b/aurex-runtime/src/lib.rs
@@ -1,6 +1,9 @@
 //! AUREX runtime orchestrates agent execution and dispatches operations to the appropriate backend.
 use async_trait::async_trait;
 
+pub mod plugin;
+pub use plugin::{BackendPlugin, PluginRegistry};
+
 /// Events emitted by the runtime to drive higher level state machines.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum RuntimeEvent {

--- a/aurex-runtime/src/plugin.rs
+++ b/aurex-runtime/src/plugin.rs
@@ -1,0 +1,65 @@
+#![allow(improper_ctypes_definitions)]
+
+use libloading::{Library, Symbol};
+use std::collections::HashMap;
+
+/// Trait implemented by backend plugins.
+pub trait BackendPlugin: Send + Sync {
+    /// Name used to register the plugin.
+    fn name(&self) -> &'static str;
+    /// Called once when the plugin is loaded.
+    fn initialize(&self);
+    /// Execute the plugin's main functionality.
+    fn execute(&self);
+}
+
+// Signature of the plugin constructor function exported by dynamic libraries.
+type PluginCreate = unsafe extern "C" fn() -> *mut dyn BackendPlugin;
+
+/// Registry that loads backend plugins dynamically and stores them by name.
+pub struct PluginRegistry {
+    plugins: HashMap<String, Box<dyn BackendPlugin>>,
+    // Hold libraries to ensure they remain loaded for the lifetime of the registry.
+    libs: Vec<Library>,
+}
+
+impl PluginRegistry {
+    /// Create an empty plugin registry.
+    pub fn new() -> Self {
+        Self {
+            plugins: HashMap::new(),
+            libs: Vec::new(),
+        }
+    }
+
+    /// Load a plugin dynamic library from `path` and register it.
+    ///
+    /// # Safety
+    ///
+    /// Loading arbitrary dynamic libraries is inherently unsafe. The caller must
+    /// ensure the library is trusted and follows the expected ABI.
+    pub unsafe fn load(&mut self, path: &str) -> Result<(), libloading::Error> {
+        let lib = Library::new(path)?;
+        let constructor: Symbol<PluginCreate> = lib.get(b"create_plugin")?;
+        let plugin = Box::<dyn BackendPlugin>::from_raw(constructor());
+        plugin.initialize();
+        let name = plugin.name().to_string();
+        self.plugins.insert(name, plugin);
+        self.libs.push(lib);
+        Ok(())
+    }
+
+    /// Execute a previously loaded plugin by name.
+    pub fn execute(&self, name: &str) {
+        if let Some(plugin) = self.plugins.get(name) {
+            plugin.execute();
+        } else {
+            eprintln!("Plugin '{}' not found", name);
+        }
+    }
+
+    /// List the names of all loaded plugins.
+    pub fn list(&self) -> Vec<&str> {
+        self.plugins.keys().map(|k| k.as_str()).collect()
+    }
+}


### PR DESCRIPTION
## Summary
- add plugin registry to runtime for dynamically loading backend plugins
- implement FPGA/NPU plugin using the new backend trait
- add example demonstrating plugin initialization and execution

## Testing
- `cargo test -p aurex-runtime`
- `cargo test -p fpga_npu`
- `cargo run -p aurex-runtime --example plugin_demo`
