### PR TITLE
Add tests and CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,37 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  test:
+    strategy:
+      matrix:
+        backend: [cpu, rocm, sycl, opencl]
+    runs-on: ubuntu-latest
+    env:
+      CARGO_TERM_COLOR: always
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+      - name: Run tests
+        run: |
+          if [ "${{matrix.backend}}" = "cpu" ]; then
+            export AUREX_DISABLE_ROCM=1
+            export AUREX_DISABLE_SYCL=1
+            export AUREX_DISABLE_OPENCL=1
+          elif [ "${{matrix.backend}}" = "rocm" ]; then
+            export AUREX_DISABLE_SYCL=1
+            export AUREX_DISABLE_OPENCL=1
+          elif [ "${{matrix.backend}}" = "sycl" ]; then
+            export AUREX_DISABLE_ROCM=1
+            export AUREX_DISABLE_OPENCL=1
+          elif [ "${{matrix.backend}}" = "opencl" ]; then
+            export AUREX_DISABLE_ROCM=1
+            export AUREX_DISABLE_SYCL=1
+          fi
+          cargo test --workspace --all-targets

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -32,6 +32,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "ash",
+ "async-trait",
  "aurex-runtime",
  "criterion",
  "half",

--- a/amduda/Cargo.toml
+++ b/amduda/Cargo.toml
@@ -18,6 +18,7 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 memmap2 = "0.5"
 half = "2"
+async-trait = "0.1"
 
 [dev-dependencies]
 tokio = { version = "1", features = ["rt-multi-thread"] }

--- a/aurex-backend/tests/ops.rs
+++ b/aurex-backend/tests/ops.rs
@@ -1,0 +1,52 @@
+use aurex_backend::dispatch::{TensorOps, CpuBackend, RocmBackend, SyclBackend, OpenClBackend};
+
+fn all_backends() -> Vec<Box<dyn TensorOps>> {
+    vec![
+        Box::new(CpuBackend),
+        Box::new(RocmBackend),
+        Box::new(SyclBackend),
+        Box::new(OpenClBackend),
+    ]
+}
+
+#[test]
+fn matmul_consistency() {
+    let a = vec![1.0, 2.0, 3.0, 4.0];
+    let b = vec![5.0, 6.0, 7.0, 8.0];
+    let expected = vec![19.0, 22.0, 43.0, 50.0];
+    for backend in all_backends() {
+        assert_eq!(backend.matmul(&a, &b, 2, 2, 2), expected);
+    }
+}
+
+#[test]
+fn conv2d_consistency() {
+    let input = vec![1.0, 2.0, 3.0, 4.0]; // 2x2
+    let kernel = vec![1.0];
+    for backend in all_backends() {
+        assert_eq!(backend.conv2d(&input, &kernel, (2, 2), (1, 1)), input);
+    }
+}
+
+#[test]
+fn attention_consistency() {
+    let q = vec![1.0, 0.0];
+    let k = vec![1.0, 0.0];
+    let v = vec![0.5, -0.5];
+    let expected = vec![0.25, -0.25];
+    for backend in all_backends() {
+        assert_eq!(backend.attention(&q, &k, &v, 2), expected);
+    }
+}
+
+#[test]
+fn layer_norm_consistency() {
+    let x = vec![1.0, 2.0];
+    let gamma = vec![1.0, 1.0];
+    let beta = vec![0.0, 0.0];
+    for backend in all_backends() {
+        let out = backend.layer_norm(&x, &gamma, &beta, 1e-5);
+        assert!((out[0] - (-1.0)).abs() < 1e-4);
+        assert!((out[1] - 1.0).abs() < 1e-4);
+    }
+}

--- a/aurex-plugins/fpga_npu/tests/basic.rs
+++ b/aurex-plugins/fpga_npu/tests/basic.rs
@@ -1,0 +1,8 @@
+use aurex_runtime::BackendPlugin;
+use fpga_npu::create_plugin;
+
+#[test]
+fn plugin_creates_and_reports_name() {
+    let plugin: Box<dyn BackendPlugin> = unsafe { Box::from_raw(create_plugin()) };
+    assert_eq!(plugin.name(), "fpga_npu");
+}

--- a/tests/agent_loop.rs
+++ b/tests/agent_loop.rs
@@ -1,0 +1,8 @@
+use aurex_agent::agent::BasicAgent;
+use aurex_runtime::Executor;
+
+#[tokio::test]
+async fn basic_agent_executes_loop() {
+    let agent = BasicAgent;
+    agent.execute().await;
+}

--- a/tests/multi_backend_inference.rs
+++ b/tests/multi_backend_inference.rs
@@ -1,0 +1,12 @@
+use aurex_backend::{Backend, Dispatcher, Workload};
+
+#[test]
+fn matmul_across_backends() {
+    let a = vec![1.0, 2.0, 3.0, 4.0];
+    let b = vec![5.0, 6.0, 7.0, 8.0];
+    let expected = vec![19.0, 22.0, 43.0, 50.0];
+    for backend in [Backend::Cpu, Backend::Rocm, Backend::Sycl, Backend::OpenCl] {
+        let dispatcher = Dispatcher::new(Some(backend), Workload::Light);
+        assert_eq!(dispatcher.matmul(&a, &b, 2, 2, 2), expected);
+    }
+}


### PR DESCRIPTION
## Summary
- Add TensorOps unit tests covering matmul, convolution, attention, and layer norm across CPU and GPU backends
- Add plugin registry and FPGA/NPU plugin tests
- Add system and acceptance tests plus CI matrix for backend coverage

## Testing
- `cargo test --workspace`