### PR TITLE
Add TensorOps example and documentation

### DIFF
--- a/amduda/examples/fused_tensor_ops.rs
+++ b/amduda/examples/fused_tensor_ops.rs
@@ -1,0 +1,38 @@
+use amduda::amduda_core::tensor_ops::TensorOps;
+use amduda::hal_backends::{cpu_simd::CpuSimdBackend, rocm_backend::RocmBackend, vulkan_backend};
+
+fn main() {
+    // Instantiate backends. GPU backends fall back to CPU when unavailable.
+    let cpu = CpuSimdBackend;
+    let rocm = RocmBackend::new();
+    let vulkan = vulkan_backend::init().ok();
+
+    // MatMul on ROCm GPU
+    let a = vec![1.0f32, 2.0, 3.0, 4.0];
+    let b = vec![5.0f32, 6.0, 7.0, 8.0];
+    let mm = rocm.matmul(&a, &b, 2, 2, 2);
+
+    // Attention on CPU using pieces of matmul output
+    let q = vec![mm[0], mm[1]];
+    let k = vec![mm[2], mm[3]];
+    let v = vec![0.5f32, -0.5];
+    let attn = cpu.attention(&q, &k, &v, 2);
+
+    // Conv2d on Vulkan if available, otherwise CPU
+    let input = vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0];
+    let kernel = vec![1.0, 0.0, 0.0, 1.0];
+    let conv = vulkan.map_or_else(
+        || cpu.conv2d(&input, &kernel, (3, 3), (2, 2)),
+        |vk| vk.conv2d(&input, &kernel, (3, 3), (2, 2)),
+    );
+
+    // LayerNorm on CPU
+    let gamma = vec![1.0; conv.len()];
+    let beta = vec![0.0; conv.len()];
+    let norm = cpu.layer_norm(&conv, &gamma, &beta, 1e-5);
+
+    println!("MatMul:   {:?}", mm);
+    println!("Attention:{:?}", attn);
+    println!("Conv2d:   {:?}", conv);
+    println!("LayerNorm:{:?}", norm);
+}

--- a/docs/tensor_ops.md
+++ b/docs/tensor_ops.md
@@ -1,0 +1,44 @@
+# TensorOps Trait and Backend Mapping
+
+Aurex exposes a `TensorOps` trait that provides basic linear algebra primitives:
+`matmul`, `conv2d`, `attention` and `layer_norm`. Each hardware backend
+implements this trait allowing the same code to run across CPU or GPU devices.
+
+## Selecting Backends
+
+The hardware abstraction layer lives in `amduda::hal_backends`. Backends include:
+
+- `CpuSimdBackend` – portable SIMD implementation on the host
+- `RocmBackend` – AMD ROCm GPU backend
+- `VulkanBackend` – Vulkan compute backend
+- `OpenClBackend`, `SyclBackend`, `RiscvBackend` – additional targets used in
+  tests
+
+Applications can choose a backend directly or use `select_backend()` which
+consults the `AUREX_BACKEND` environment variable. If the requested backend is
+not available, the dispatcher falls back to the CPU implementation.
+
+```rust
+use amduda::amduda_core::tensor_ops::TensorOps;
+use amduda::hal_backends::{self, cpu_simd::CpuSimdBackend};
+
+fn main() {
+    let backend = match hal_backends::select_backend() {
+        hal_backends::BackendKind::Rocm => hal_backends::rocm_backend::RocmBackend::new(),
+        hal_backends::BackendKind::Vulkan => hal_backends::vulkan_backend::init().unwrap().into(),
+        _ => CpuSimdBackend,
+    };
+
+    let a = vec![1.0, 2.0, 3.0, 4.0];
+    let b = vec![5.0, 6.0, 7.0, 8.0];
+    let out = backend.matmul(&a, &b, 2, 2, 2);
+    println!("{out:?}");
+}
+```
+
+## Heterogeneous Execution
+
+Different backends can be used for different operations, enabling heterogeneous
+execution. See `examples/fused_tensor_ops.rs` for a complete example that routes
+`matmul`, `conv2d`, `attention` and `layer_norm` to separate backends.
+

--- a/examples/fused_tensor_ops.rs
+++ b/examples/fused_tensor_ops.rs
@@ -1,0 +1,38 @@
+use amduda::amduda_core::tensor_ops::TensorOps;
+use amduda::hal_backends::{cpu_simd::CpuSimdBackend, rocm_backend::RocmBackend, vulkan_backend};
+
+fn main() {
+    // Instantiate backends. GPU backends fall back to CPU when unavailable.
+    let cpu = CpuSimdBackend;
+    let rocm = RocmBackend::new();
+    let vulkan = vulkan_backend::init().ok();
+
+    // MatMul on ROCm GPU
+    let a = vec![1.0f32, 2.0, 3.0, 4.0];
+    let b = vec![5.0f32, 6.0, 7.0, 8.0];
+    let mm = rocm.matmul(&a, &b, 2, 2, 2);
+
+    // Attention on CPU using pieces of matmul output
+    let q = vec![mm[0], mm[1]];
+    let k = vec![mm[2], mm[3]];
+    let v = vec![0.5f32, -0.5];
+    let attn = cpu.attention(&q, &k, &v, 2);
+
+    // Conv2d on Vulkan if available, otherwise CPU
+    let input = vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0];
+    let kernel = vec![1.0, 0.0, 0.0, 1.0];
+    let conv = vulkan.map_or_else(
+        || cpu.conv2d(&input, &kernel, (3, 3), (2, 2)),
+        |vk| vk.conv2d(&input, &kernel, (3, 3), (2, 2)),
+    );
+
+    // LayerNorm on CPU
+    let gamma = vec![1.0; conv.len()];
+    let beta = vec![0.0; conv.len()];
+    let norm = cpu.layer_norm(&conv, &gamma, &beta, 1e-5);
+
+    println!("MatMul:   {:?}", mm);
+    println!("Attention:{:?}", attn);
+    println!("Conv2d:   {:?}", conv);
+    println!("LayerNorm:{:?}", norm);
+}


### PR DESCRIPTION
## Summary
- Document TensorOps trait usage and backend selection
- Add fused tensor ops example using CPU, ROCm, and Vulkan backends

## Testing
- `cargo test -p amduda`
- `cargo check -p amduda --example fused_tensor_ops`

------
https://chatgpt.com/codex/tasks/task_e_689df82389b48332bf5a1e4aab1f17c3