### PR TITLE
Gate JIT example and upgrade workspace resolver

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,4 +1,5 @@
 [workspace]
+resolver = "2"
 members = [
     "aurex-runtime",
     "aurex-kernel",

--- a/amduda/Cargo.toml
+++ b/amduda/Cargo.toml
@@ -34,3 +34,8 @@ jit = ["llvm-sys"]
 [[bench]]
 name = "simd_vs_scalar"
 harness = false
+
+[[example]]
+name = "jit_attention"
+path = "examples/jit_attention.rs"
+required-features = ["jit"]

--- a/amduda/examples/jit_attention.rs
+++ b/amduda/examples/jit_attention.rs
@@ -1,0 +1,18 @@
+#[cfg(feature = "jit")]
+use amduda::amduda_core::jit_compiler::{compile_kernel, Device};
+
+fn main() {
+    #[cfg(feature = "jit")]
+    {
+        // Compile a simple "add" kernel and execute it.
+        let kernel = compile_kernel("add", Device::CPU).expect("compile kernel");
+        let result = (kernel.func)(2, 3);
+        println!("2 + 3 = {}", result);
+    }
+
+    #[cfg(not(feature = "jit"))]
+    {
+        // Example available only when JIT feature is enabled.
+        eprintln!("The `jit` feature is not enabled. Enable it to run this example.");
+    }
+}


### PR DESCRIPTION
## Summary
- Gate the `jit_attention` example behind the `jit` feature and provide a stub message when the feature is disabled
- Register the example in `amduda` with required features so it only builds when JIT support is enabled
- Opt-in to Cargo's resolver 2 in the workspace to silence resolver warnings

## Testing
- `cargo test --examples`
- `cargo test`

