### PR TITLE
Add ROCm backend scaffolding with tests and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,8 @@ ROCm stack.
    cargo test -p amduda --features rocm
    ```
 
+See [docs/backends/rocm.md](docs/backends/rocm.md) for detailed setup and usage instructions, including runtime selection and fallback behaviour.
+
 The build falls back to a CPU implementation when ROCm is not present so the
 project can still be compiled and tested on systems without AMD GPUs.
 

--- a/amduda/tests/rocm/basic.rs
+++ b/amduda/tests/rocm/basic.rs
@@ -1,0 +1,32 @@
+use amduda::hal_backends::rocm_backend::RocmBackend;
+use std::ffi::c_void;
+
+#[test]
+fn device_enumeration_reports_at_least_one_device() {
+    let devices = RocmBackend::enumerate();
+    assert!(!devices.is_empty());
+}
+
+#[test]
+fn memory_roundtrip_via_backend() {
+    let backend = RocmBackend::new();
+    unsafe {
+        let ptr = backend.alloc(4 * std::mem::size_of::<u32>());
+        let host = [1u32, 2, 3, 4];
+        backend.memcpy_htod(ptr, host.as_ptr() as *const c_void, 16);
+        let mut out = [0u32; 4];
+        backend.memcpy_dtoh(out.as_mut_ptr() as *mut c_void, ptr, 16);
+        backend.free(ptr);
+        assert_eq!(host, out);
+    }
+}
+
+#[test]
+fn kernel_launch_executes_closure() {
+    let backend = RocmBackend::new();
+    let mut executed = false;
+    backend.launch(|| {
+        executed = true;
+    });
+    assert!(executed);
+}

--- a/amduda/tests/rocm/mod.rs
+++ b/amduda/tests/rocm/mod.rs
@@ -1,0 +1,1 @@
+mod basic;

--- a/amduda/tests/rocm_backend.rs
+++ b/amduda/tests/rocm_backend.rs
@@ -1,0 +1,1 @@
+mod rocm;

--- a/docs/backends/rocm.md
+++ b/docs/backends/rocm.md
@@ -1,0 +1,26 @@
+# ROCm Backend
+
+AUREX supports executing tensor kernels on AMD GPUs through the ROCm/HIP runtime. The container used for testing does not ship with ROCm, but the backend emulates the public API so code can still be exercised on machines without GPUs.
+
+## Prerequisites
+1. Install **ROCm 6.0 or newer** following the instructions for your distribution at [rocm.docs.amd.com](https://rocm.docs.amd.com).
+2. Add `/opt/rocm/bin` to `PATH` and `/opt/rocm/lib` to `LD_LIBRARY_PATH` so that the HIP tools and libraries can be located.
+3. Verify the installation with `rocminfo` and `hipcc --version`.
+
+## Building
+Enable the backend when running tests or examples by activating the `rocm` feature on the `amduda` crate:
+
+```sh
+cargo test -p amduda --features rocm
+```
+
+If ROCm is absent the build automatically falls back to a host implementation, allowing development and CI to run without a GPU.
+
+## Using the Backend
+Select the backend at runtime via the `AUREX_BACKEND` environment variable. When the ROCm backend is requested but no GPU is present the dispatcher gracefully falls back to the CPU implementation.
+
+```sh
+AUREX_BACKEND=rocm cargo run --example fused_tensor_ops
+```
+
+This will execute tensor operations on the GPU when available or on the CPU otherwise, ensuring cross-backend compatibility.


### PR DESCRIPTION
## Summary
- flesh out ROCm backend with device enumeration, memory copy helpers and simulated kernel launch
- add dedicated ROCm backend tests exercising enumeration, memory roundtrip and kernel launch
- document ROCm setup and usage and link from README

## Testing
- `cargo test -p amduda`
- `cargo test -p amduda --test rocm_backend -- --nocapture`