### PR TITLE
Add AVX SIMD backend and benchmarks

### DIFF
--- a/amduda/src/hal_backends/mod.rs
+++ b/amduda/src/hal_backends/mod.rs
@@ -26,7 +26,8 @@ pub enum BackendKind {
 }
 
 /// Select a backend based on the `AUREX_BACKEND` environment variable.  If the
-/// requested backend is unavailable we fall back to the CPU implementation.
+/// requested backend is unavailable we fall back to the SIMD-accelerated CPU
+/// implementation so that tensor ops still benefit from vectorization.
 pub fn select_backend() -> BackendKind {
     match std::env::var("AUREX_BACKEND")
         .unwrap_or_default()


### PR DESCRIPTION
## Summary
- implement AVX-based SIMD `TensorOps` backend using `std::arch`
- ensure backend selection falls back to SIMD CPU when GPU unavailable
- add criterion benchmarks comparing scalar and SIMD implementations

## Testing
- `cargo test`
- `cargo bench --bench simd_vs_scalar --no-run`