### PR TITLE
Add backend dispatcher env selection and tests

### DIFF
--- a/aurex-backend/src/lib.rs
+++ b/aurex-backend/src/lib.rs
@@ -4,6 +4,6 @@ pub mod dispatch;
 pub mod vulkan_backend;
 pub mod sycl_backend;
 
-pub use dispatch::{Backend, Dispatcher, Workload};
+pub use dispatch::{Backend, Dispatcher, Workload, TensorOps};
 pub use vulkan_backend::VulkanBackend;
 pub use sycl_backend::SyclBackend;

--- a/aurex-backend/tests/dispatch.rs
+++ b/aurex-backend/tests/dispatch.rs
@@ -5,6 +5,8 @@ fn reset_env() {
     std::env::remove_var("AUREX_DISABLE_ROCM");
     std::env::remove_var("AUREX_DISABLE_OPENCL");
     std::env::remove_var("AUREX_DISABLE_SYCL");
+    std::env::remove_var("AUREX_DISABLE_VULKAN");
+    std::env::remove_var("AUREX_BACKEND");
 }
 
 #[test]
@@ -13,6 +15,15 @@ fn honors_user_preference() {
     reset_env();
     let d = Dispatcher::new(Some(Backend::Sycl), Workload::Light);
     assert_eq!(d.backend(), Backend::Sycl);
+}
+
+#[test]
+#[serial]
+fn env_var_overrides_workload() {
+    reset_env();
+    std::env::set_var("AUREX_BACKEND", "opencl");
+    let d = Dispatcher::new(None, Workload::Light);
+    assert_eq!(d.backend(), Backend::OpenCl);
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- allow Dispatcher to honor `AUREX_BACKEND` env var and provide helper
- re-export TensorOps from aurex-backend
- add unit tests covering backend selection and env overrides

## Testing
- `cargo test -p aurex-backend` *(fails: shaderc-sys compilation did not complete)*
