### PR TITLE
Add block-sparse paged attention with memory-tiered caching

### DIFF
--- a/amduda/src/aurex_lm/paged_attention.rs
+++ b/amduda/src/aurex_lm/paged_attention.rs
@@ -1,10 +1,13 @@
-//! Sliding-window paged attention leveraging the memory tiering subsystem.
+//! Sliding‑window and block‑sparse paged attention leveraging the memory
+//! tiering subsystem.
 //!
-//! This is a very small reference implementation that demonstrates how key
-//! and value pages may be allocated across memory tiers and migrated for a
-//! sliding‑window attention computation.  The algorithm is intentionally
-//! simple: for each query position we attend only to the most recent
-//! `window` keys.
+//! The primary entry point is [`PagedAttention`], which owns a
+//! [`MemoryManager`] and exposes two reference implementations:
+//! `compute` implements a classic sliding window, while
+//! `compute_block_sparse` operates on blocks of tokens.  Both methods
+//! demonstrate how key and value pages may be allocated across memory tiers
+//! and migrated between NVMe and CPU memory to efficiently handle large
+//! contexts.
 
 use crate::amduda_core::memory_tiering::{DeviceCapabilities, MemoryManager, MemoryTier};
 use std::mem::size_of;
@@ -120,6 +123,120 @@ impl PagedAttention {
                 let v_j = &v[*j * d..(*j + 1) * d];
                 for (out, val) in output[i * d..(i + 1) * d].iter_mut().zip(v_j.iter()) {
                     *out += weight * val;
+                }
+            }
+        }
+
+        AttentionResult {
+            output,
+            k_tier,
+            v_tier,
+        }
+    }
+
+    /// Compute block‑sparse attention where each token only attends to a
+    /// limited number of previous blocks.
+    ///
+    /// * `block_size` – number of tokens per block.
+    /// * `block_window` – number of previous blocks (including the current
+    ///   one) that are visible to each block.
+    pub fn compute_block_sparse(
+        &mut self,
+        q: &[f32],
+        k: &[f32],
+        v: &[f32],
+        d: usize,
+        block_size: usize,
+        block_window: usize,
+    ) -> AttentionResult {
+        assert_eq!(k.len(), v.len());
+        assert_eq!(q.len() % d, 0);
+        assert_eq!(k.len() % d, 0);
+
+        let n = q.len() / d;
+        assert_eq!(n, k.len() / d, "q, k and v must have the same number of tokens");
+        assert!(block_size > 0);
+        let n_blocks = (n + block_size - 1) / block_size;
+
+        // Allocate key/value buffers using tiering.
+        let byte_len = k.len() * size_of::<f32>();
+        let k_tier = self.mgr.allocate(byte_len);
+        let v_tier = self.mgr.allocate(byte_len);
+
+        // Bring the initial window of blocks into CPU memory if backing store
+        // is NVMe.  This models a simple cache of hot blocks.
+        let block_bytes = block_size * d * size_of::<f32>();
+        let init_blocks = block_window.min(n_blocks);
+        let window_bytes = init_blocks * block_bytes;
+        if matches!(k_tier, MemoryTier::Nvme) {
+            self.mgr
+                .migrate(MemoryTier::Nvme, MemoryTier::Cpu, window_bytes);
+            self.mgr.mark_hot(MemoryTier::Cpu, window_bytes);
+        }
+        if matches!(v_tier, MemoryTier::Nvme) {
+            self.mgr
+                .migrate(MemoryTier::Nvme, MemoryTier::Cpu, window_bytes);
+            self.mgr.mark_hot(MemoryTier::Cpu, window_bytes);
+        }
+
+        let mut output = vec![0f32; n * d];
+        for b in 0..n_blocks {
+            let q_start = b * block_size;
+            let q_end = (q_start + block_size).min(n);
+            let first_block = b.saturating_sub(block_window - 1);
+            let ctx_start = first_block * block_size;
+
+            for i in q_start..q_end {
+                let q_i = &q[i * d..(i + 1) * d];
+                let mut scores = Vec::new();
+                for j in ctx_start..=i {
+                    let k_j = &k[j * d..(j + 1) * d];
+                    let dot: f32 = q_i.iter().zip(k_j.iter()).map(|(a, b)| a * b).sum();
+                    scores.push((j, dot));
+                }
+
+                let max_score = scores
+                    .iter()
+                    .map(|(_, s)| *s)
+                    .fold(f32::NEG_INFINITY, f32::max);
+                let mut denom = 0f32;
+                let mut weights = Vec::new();
+                for &(_, s) in &scores {
+                    let w = (s - max_score).exp();
+                    denom += w;
+                    weights.push(w);
+                }
+
+                for ((j, _), w) in scores.iter().zip(weights.iter()) {
+                    let weight = *w / denom;
+                    let v_j = &v[*j * d..(*j + 1) * d];
+                    for (out, val) in output[i * d..(i + 1) * d].iter_mut().zip(v_j.iter()) {
+                        *out += weight * val;
+                    }
+                }
+            }
+
+            // Update cache for next block.
+            if b + 1 < n_blocks {
+                if matches!(k_tier, MemoryTier::Nvme) {
+                    if b + 1 >= block_window {
+                        self.mgr.mark_cold(MemoryTier::Cpu, block_bytes);
+                        self.mgr
+                            .migrate(MemoryTier::Cpu, MemoryTier::Nvme, block_bytes);
+                    }
+                    self.mgr
+                        .migrate(MemoryTier::Nvme, MemoryTier::Cpu, block_bytes);
+                    self.mgr.mark_hot(MemoryTier::Cpu, block_bytes);
+                }
+                if matches!(v_tier, MemoryTier::Nvme) {
+                    if b + 1 >= block_window {
+                        self.mgr.mark_cold(MemoryTier::Cpu, block_bytes);
+                        self.mgr
+                            .migrate(MemoryTier::Cpu, MemoryTier::Nvme, block_bytes);
+                    }
+                    self.mgr
+                        .migrate(MemoryTier::Nvme, MemoryTier::Cpu, block_bytes);
+                    self.mgr.mark_hot(MemoryTier::Cpu, block_bytes);
                 }
             }
         }

--- a/amduda/tests/test_paged_attention.rs
+++ b/amduda/tests/test_paged_attention.rs
@@ -40,6 +40,54 @@ fn naive_sliding_window(q: &[f32], k: &[f32], v: &[f32], d: usize, window: usize
     out
 }
 
+fn naive_block_sparse(
+    q: &[f32],
+    k: &[f32],
+    v: &[f32],
+    d: usize,
+    block_size: usize,
+    block_window: usize,
+) -> Vec<f32> {
+    assert_eq!(k.len(), v.len());
+    let n = q.len() / d;
+    let mut out = vec![0f32; n * d];
+    let n_blocks = (n + block_size - 1) / block_size;
+    for b in 0..n_blocks {
+        let q_start = b * block_size;
+        let q_end = (q_start + block_size).min(n);
+        let first_block = b.saturating_sub(block_window - 1);
+        let ctx_start = first_block * block_size;
+        for i in q_start..q_end {
+            let q_i = &q[i * d..(i + 1) * d];
+            let mut scores = Vec::new();
+            for j in ctx_start..=i {
+                let k_j = &k[j * d..(j + 1) * d];
+                let dot: f32 = q_i.iter().zip(k_j.iter()).map(|(a, b)| a * b).sum();
+                scores.push((j, dot));
+            }
+            let max_score = scores
+                .iter()
+                .map(|(_, s)| *s)
+                .fold(f32::NEG_INFINITY, f32::max);
+            let mut denom = 0f32;
+            let mut weights = Vec::new();
+            for &(_, s) in &scores {
+                let w = (s - max_score).exp();
+                denom += w;
+                weights.push(w);
+            }
+            for ((j, _), w) in scores.iter().zip(weights.iter()) {
+                let weight = *w / denom;
+                let v_j = &v[*j * d..(*j + 1) * d];
+                for (o, val) in out[i * d..(i + 1) * d].iter_mut().zip(v_j.iter()) {
+                    *o += weight * val;
+                }
+            }
+        }
+    }
+    out
+}
+
 #[test]
 #[serial]
 fn sliding_window_attention_correctness_and_tiering() {
@@ -67,4 +115,38 @@ fn sliding_window_attention_correctness_and_tiering() {
 
     let usage = attn.usage();
     assert_eq!(usage, (0, 16, 48));
+}
+
+#[test]
+#[serial]
+fn block_sparse_attention_correctness_and_tiering() {
+    std::env::set_var("AMDUDA_HAS_GPU", "0");
+    std::env::set_var("AMDUDA_HAS_NVME", "1");
+    let caps = DeviceCapabilities::detect();
+    let mut attn = PagedAttention::new_with_limits(caps, 0, 32, 1024);
+
+    let d = 2;
+    let q = vec![
+        1.0, 0.0, 0.0, 1.0, 1.0, 1.0, 0.5, 0.5, 0.2, 0.8, 0.8, 0.2, 0.3, 0.7, 0.7, 0.3,
+    ];
+    let k = q.clone();
+    let v = vec![
+        1.0, 0.0, 0.0, 1.0, 1.0, 1.0, 0.5, 1.0, 0.2, 0.8, 0.8, 0.2, 0.3, 0.7, 0.7, 0.3,
+    ];
+    let block_size = 2;
+    let block_window = 1;
+
+    let result = attn.compute_block_sparse(&q, &k, &v, d, block_size, block_window);
+    let expected = naive_block_sparse(&q, &k, &v, d, block_size, block_window);
+
+    assert!(result
+        .output
+        .iter()
+        .zip(expected.iter())
+        .all(|(a, b)| (a - b).abs() < 1e-5));
+    assert_eq!(result.k_tier, MemoryTier::Nvme);
+    assert_eq!(result.v_tier, MemoryTier::Nvme);
+
+    let usage = attn.usage();
+    assert_eq!(usage, (0, 32, 96));
 }


### PR DESCRIPTION
## Summary
- implement block-sparse attention variant that migrates blocks across NVMe and CPU tiers
- document paged attention now supporting sliding-window and block-sparse modes
- add tests for block-sparse attention and tiered memory usage

## Testing
- `cargo test -p amduda --test test_paged_attention`
- `cargo test -p amduda`
